### PR TITLE
Overhaul of GUI API

### DIFF
--- a/core/src/main/java/me/wolfyscript/utilities/api/config/YamlConfiguration.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/config/YamlConfiguration.java
@@ -159,7 +159,7 @@ public class YamlConfiguration extends org.bukkit.configuration.file.YamlConfigu
      */
     public void loadDefaults() {
         save();
-        options().copyDefaults(false);
+        options().copyDefaults(true);
         Reader stream;
         try {
             String fileName = defFileName.isEmpty() ? getName() : defFileName;

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/GuiHandler.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/GuiHandler.java
@@ -76,14 +76,6 @@ public class GuiHandler<C extends CustomCache> implements Listener, InventoryHol
         return isWindowOpen;
     }
 
-    public boolean verifyInventory(Inventory inventory) {
-        if (isWindowOpen() && getWindow() != null) {
-            Inventory windowInv = getWindow().getInventory(this);
-            return windowInv == inventory;
-        }
-        return false;
-    }
-
     /*
     Reloads the GuiWindow of the GuiCluster.
      */

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/GuiHandler.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/GuiHandler.java
@@ -11,14 +11,12 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.event.player.PlayerCommandPreprocessEvent;
-import org.bukkit.inventory.Inventory;
-import org.bukkit.inventory.InventoryHolder;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
 
-public class GuiHandler<C extends CustomCache> implements Listener, InventoryHolder {
+public class GuiHandler<C extends CustomCache> implements Listener {
 
     private final WolfyUtilities api;
     private final InventoryAPI<C> invAPI;
@@ -222,7 +220,7 @@ public class GuiHandler<C extends CustomCache> implements Listener, InventoryHol
                 clusterHistory.put(cluster, history);
                 this.cluster = cluster;
                 isWindowOpen = true;
-                window.update(this, null, null, true);
+                window.create(this);
                 return;
             }
             api.getChat().sendPlayerMessage(player1, "§4You don't have the permission §c" + (api.getPlugin().getName() + ".inv." + window.getNamespacedKey().toString(".")));
@@ -330,11 +328,5 @@ public class GuiHandler<C extends CustomCache> implements Listener, InventoryHol
 
     public C getCustomCache() {
         return customCache;
-    }
-
-    @NotNull
-    @Override
-    public Inventory getInventory() {
-        return null;
     }
 }

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/GuiHandler.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/GuiHandler.java
@@ -12,22 +12,23 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.event.player.PlayerCommandPreprocessEvent;
 import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
 
-public class GuiHandler<C extends CustomCache> implements Listener {
+public class GuiHandler<C extends CustomCache> implements Listener, InventoryHolder {
 
     private final WolfyUtilities api;
     private final InventoryAPI<C> invAPI;
     private final UUID uuid;
-    private final HashMap<String, List<String>> clusterHistory = new HashMap<>();
+    private final HashMap<GuiCluster<C>, List<GuiWindow<C>>> clusterHistory = new HashMap<>();
     private ChatInputAction<C> chatInputAction = null;
-    private String currentGuiCluster = "";
+    private GuiCluster<C> cluster = null;
     private boolean isWindowOpen = false;
     private boolean helpEnabled = false;
-    private boolean changingInv = false;
+    private boolean switchWindow = false;
 
     private final C customCache;
 
@@ -39,8 +40,8 @@ public class GuiHandler<C extends CustomCache> implements Listener {
         Bukkit.getPluginManager().registerEvents(this, api.getPlugin());
     }
 
-    public void setChangingInv(boolean changingInv) {
-        this.changingInv = changingInv;
+    void setSwitchWindow(boolean switchWindow) {
+        this.switchWindow = switchWindow;
     }
 
     public WolfyUtilities getApi() {
@@ -60,12 +61,12 @@ public class GuiHandler<C extends CustomCache> implements Listener {
         return getPlayer() != null;
     }
 
-    public String getCurrentGuiCluster() {
-        return currentGuiCluster;
+    public GuiCluster<C> getCluster() {
+        return cluster;
     }
 
-    public void setCurrentGuiCluster(String currentGuiCluster) {
-        this.currentGuiCluster = currentGuiCluster;
+    public void setCluster(GuiCluster<C> currentGuiCluster) {
+        this.cluster = currentGuiCluster;
     }
 
     /*
@@ -76,121 +77,163 @@ public class GuiHandler<C extends CustomCache> implements Listener {
     }
 
     public boolean verifyInventory(Inventory inventory) {
-        return isWindowOpen() && getCurrentInv() != null && getCurrentInv().getInventory(this).equals(inventory);
+        if (isWindowOpen() && getWindow() != null) {
+            Inventory windowInv = getWindow().getInventory(this);
+            return windowInv == inventory;
+        }
+        return false;
     }
 
     /*
     Reloads the GuiWindow of the GuiCluster.
      */
-    public void reloadInv(NamespacedKey namespacedKey) {
-        List<String> history = clusterHistory.getOrDefault(namespacedKey.getNamespace(), new ArrayList<>());
+    public void reloadWindow(NamespacedKey namespacedKey) {
+        GuiCluster<C> cluster = invAPI.getGuiCluster(namespacedKey.getNamespace());
+        List<GuiWindow<C>> history = clusterHistory.getOrDefault(cluster, new ArrayList<>());
         history.remove(history.get(history.size() - 1));
-        clusterHistory.put(namespacedKey.getNamespace(), history);
-        changeToInv(namespacedKey);
+        clusterHistory.put(cluster, history);
+        openWindow(namespacedKey);
+    }
+
+    public GuiWindow<C> getWindow(String clusterID) {
+        return getWindow(invAPI.getGuiCluster(clusterID));
     }
 
     /*
     Gets the current GuiWindow. If the Gui isn't opened then the latest GuiWindow is returned.
      */
     @Nullable
-    public GuiWindow<C> getCurrentInv(String clusterID) {
-        if (clusterHistory.get(clusterID) != null && clusterHistory.get(clusterID).size() > 0) {
-            return invAPI.getGuiWindow(new NamespacedKey(clusterID, clusterHistory.get(clusterID).get(clusterHistory.get(clusterID).size() - 1)));
+    public GuiWindow<C> getWindow(GuiCluster<C> cluster) {
+        if (clusterHistory.get(cluster) != null && clusterHistory.get(cluster).size() > 0) {
+            return invAPI.getGuiWindow(clusterHistory.get(cluster).get(clusterHistory.get(cluster).size() - 1).getNamespacedKey());
         }
         return null;
     }
 
     @Nullable
-    public GuiWindow<C> getCurrentInv() {
-        return getCurrentInv(getCurrentGuiCluster());
+    public GuiWindow<C> getWindow() {
+        return getWindow(getCluster());
     }
 
     /*
     Gets the previous GuiWindow that was open. If there is non null is returned!
      */
     @Nullable
-    public GuiWindow<C> getPreviousInv(String clusterID) {
-        return getPreviousInv(clusterID, 2);
+    public GuiWindow<C> getPreviousWindow(String clusterID) {
+        return getPreviousWindow(invAPI.getGuiCluster(clusterID));
     }
 
     /*
     Gets the previous GuiWindow that was open. If there is non null is returned!
      */
     @Nullable
-    public GuiWindow<C> getPreviousInv(String clusterID, int stepsBack) {
-        List<String> history = clusterHistory.getOrDefault(clusterID, new ArrayList<>());
+    public GuiWindow<C> getPreviousWindow(GuiCluster<C> cluster) {
+        return getPreviousWindow(cluster, 2);
+    }
+
+    /*
+    Gets the previous GuiWindow that was open. If there is non null is returned!
+     */
+    @Nullable
+    public GuiWindow<C> getPreviousWindow(String clusterID, int stepsBack) {
+        return getPreviousWindow(invAPI.getGuiCluster(clusterID), stepsBack);
+    }
+
+    public GuiWindow<C> getPreviousWindow(GuiCluster<C> cluster, int stepsBack) {
+        List<GuiWindow<C>> history = clusterHistory.getOrDefault(cluster, new ArrayList<>());
         if (history.size() > stepsBack) {
-            return invAPI.getGuiWindow(new NamespacedKey(clusterID, history.get(history.size() - (stepsBack + 1))));
+            return invAPI.getGuiWindow(history.get(history.size() - (stepsBack + 1)).getNamespacedKey());
         }
         return null;
     }
 
-    public GuiWindow<C> getPreviousInv() {
-        return getPreviousInv(getCurrentGuiCluster());
+    public GuiWindow<C> getPreviousWindow() {
+        return getPreviousWindow(getCluster());
     }
 
-    public GuiWindow<C> getPreviousInv(int stepsBack) {
-        return getPreviousInv(getCurrentGuiCluster(), stepsBack);
+    public GuiWindow<C> getPreviousWindow(int stepsBack) {
+        return getPreviousWindow(getCluster(), stepsBack);
     }
 
-    public void openPreviousInv() {
-        openPreviousInv(getCurrentGuiCluster());
+    public void openPreviousWindow() {
+        openPreviousWindow(getCluster());
     }
 
-    public void openPreviousInv(String clusterID) {
-        openPreviousInv(clusterID, 1);
+    public void openPreviousWindow(String clusterID) {
+        openPreviousWindow(invAPI.getGuiCluster(clusterID));
     }
 
-    public void openPreviousInv(int stepsBack) {
-        openPreviousInv(getCurrentGuiCluster(), stepsBack);
+    public void openPreviousWindow(GuiCluster<C> cluster) {
+        openPreviousWindow(cluster, 1);
     }
 
-    public void openPreviousInv(String clusterID, int stepsBack) {
-        List<String> history = clusterHistory.getOrDefault(clusterID, new ArrayList<>());
+    public void openPreviousWindow(int stepsBack) {
+        openPreviousWindow(getCluster(), stepsBack);
+    }
+
+    public void openPreviousWindow(String clusterID, int stepsBack) {
+        openPreviousWindow(invAPI.getGuiCluster(clusterID));
+    }
+
+    public void openPreviousWindow(GuiCluster<C> cluster, int stepsBack) {
+        List<GuiWindow<C>> history = clusterHistory.getOrDefault(cluster, new ArrayList<>());
         for (int i = 0; i < stepsBack; i++) {
             if (!history.isEmpty()) {
                 history.remove(history.size() - 1);
             }
         }
-        clusterHistory.put(clusterID, history);
+        clusterHistory.put(cluster, history);
         if (history.isEmpty()) {
-            openCluster(clusterID);
+            openCluster(cluster);
         } else {
-            changeToInv(new NamespacedKey(clusterID, history.get(history.size() - 1)));
+            openWindow(history.get(history.size() - 1).getNamespacedKey());
         }
     }
 
-    public HashMap<String, List<String>> getClusterHistory() {
+    public HashMap<GuiCluster<C>, List<GuiWindow<C>>> getClusterHistory() {
         return clusterHistory;
     }
 
     /*
         Opens the specific GuiWindow in the current GuiCluster.
          */
-    public void changeToInv(String guiWindowID) {
-        changeToInv(new NamespacedKey(getCurrentGuiCluster(), guiWindowID));
+    public void openWindow(String guiWindowID) {
+        openWindow(new NamespacedKey(getCluster().getId(), guiWindowID));
+    }
+
+
+    public void openWindow(@NotNull NamespacedKey namespacedKey) {
+        openWindow(invAPI.getGuiWindow(namespacedKey));
     }
 
     /*
     Opens the specific GuiWindow in the specific GuiCluster.
      */
-    public void changeToInv(@NotNull NamespacedKey namespacedKey) {
+    public void openWindow(GuiWindow<C> window) {
+        if (getPlayer() == null) {
+            isWindowOpen = false;
+            return;
+        }
+        if (window == null) {
+            getPlayer().closeInventory();
+            isWindowOpen = false;
+            return;
+        }
+        final GuiCluster<C> cluster = window.getCluster();
         Bukkit.getScheduler().runTask(getApi().getPlugin(), () -> {
             Player player1 = getPlayer();
-            if (api.getPermissions().hasPermission(player1, (api.getPlugin().getName() + ".inv." + namespacedKey.getNamespace() + "." + namespacedKey.getKey()))) {
-                List<String> history = clusterHistory.getOrDefault(namespacedKey.getNamespace(), new ArrayList<>());
-                if (getCurrentInv(namespacedKey.getNamespace()) == null || !getCurrentInv(namespacedKey.getNamespace()).getNamespacedKey().equals(namespacedKey)) {
-                    history.add(namespacedKey.getKey());
+            if (api.getPermissions().hasPermission(player1, (api.getPlugin().getName() + ".inv." + window.getNamespacedKey().toString(".")))) {
+                List<GuiWindow<C>> history = clusterHistory.getOrDefault(cluster, new ArrayList<>());
+                if (getWindow(cluster) == null || !Objects.equals(getWindow(cluster), window)) {
+                    history.add(window);
                 }
-                clusterHistory.put(namespacedKey.getNamespace(), history);
-                if (invAPI.getGuiWindow(namespacedKey) != null) {
-                    currentGuiCluster = namespacedKey.getNamespace();
-                    isWindowOpen = true;
-                    invAPI.getGuiWindow(namespacedKey).update(this, null, null, true);
-                }
+                clusterHistory.put(cluster, history);
+                this.cluster = cluster;
+                isWindowOpen = true;
+                window.update(this, null, null, true);
                 return;
             }
-            api.getChat().sendPlayerMessage(player1, "§4You don't have the permission §c" + (api.getPlugin().getName() + ".inv." + namespacedKey.getNamespace() + "." + namespacedKey.getKey()));
+            api.getChat().sendPlayerMessage(player1, "§4You don't have the permission §c" + (api.getPlugin().getName() + ".inv." + window.getNamespacedKey().toString(".")));
         });
     }
 
@@ -198,18 +241,25 @@ public class GuiHandler<C extends CustomCache> implements Listener {
     Opens the current GuiCluster with the latest GuiWindow that was open.
      */
     public void openCluster() {
-        openCluster(getCurrentGuiCluster());
+        openCluster(getCluster());
     }
 
     /**
      * Opens the GuiCluster with the latest GuiWindow that was open.
      */
     public void openCluster(String clusterID) {
-        NamespacedKey guiWindowID = invAPI.getGuiCluster(clusterID).getEntry();
-        if (getCurrentInv(clusterID) != null) {
-            guiWindowID = getCurrentInv(clusterID).getNamespacedKey();
+        openCluster(invAPI.getGuiCluster(clusterID));
+    }
+
+    /**
+     * Opens the GuiCluster with the latest GuiWindow that was open.
+     */
+    public void openCluster(GuiCluster<C> cluster) {
+        NamespacedKey guiWindowID = cluster.getEntry();
+        if (getWindow(cluster) != null) {
+            guiWindowID = getWindow(cluster).getNamespacedKey();
         }
-        changeToInv(guiWindowID);
+        openWindow(guiWindowID);
     }
 
     public boolean isChatEventActive() {
@@ -246,9 +296,7 @@ public class GuiHandler<C extends CustomCache> implements Listener {
     }
 
     public void setButton(GuiWindow<C> guiWindow, int slot, String id) {
-        TreeMap<Integer, String> buttons = customCache.getButtons(guiWindow);
-        buttons.put(slot, id);
-        customCache.setButtons(guiWindow, buttons);
+        customCache.setButton(guiWindow, slot, id);
     }
 
     public Button<C> getButton(GuiWindow<C> guiWindow, int slot) {
@@ -262,8 +310,8 @@ public class GuiHandler<C extends CustomCache> implements Listener {
     @EventHandler(priority = EventPriority.HIGH)
     public void onClose(InventoryCloseEvent event) {
         if (event.getPlayer().getUniqueId().equals(uuid)) {
-            if (!clusterHistory.isEmpty() && isWindowOpen() && !changingInv) {
-                if (getCurrentInv().onClose(this, event.getView())) {
+            if (!clusterHistory.isEmpty() && isWindowOpen() && !switchWindow) {
+                if (getWindow().onClose(this, event.getView())) {
                     Bukkit.getScheduler().runTask(getApi().getPlugin(), (Runnable) this::openCluster);
                 } else {
                     this.isWindowOpen = false;
@@ -292,4 +340,9 @@ public class GuiHandler<C extends CustomCache> implements Listener {
         return customCache;
     }
 
+    @NotNull
+    @Override
+    public Inventory getInventory() {
+        return null;
+    }
 }

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/GuiUpdate.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/GuiUpdate.java
@@ -37,9 +37,9 @@ public class GuiUpdate<C extends CustomCache> {
             String guiName = guiWindow.getInventoryName();
             guiName = guiName.replace("%plugin.version%", wolfyUtilities.getPlugin().getDescription().getVersion()).replace("%plugin.author%", wolfyUtilities.getPlugin().getDescription().getAuthors().toString()).replace("%plugin.name%", wolfyUtilities.getPlugin().getDescription().getName());
             if (guiWindow.getInventoryType() == null) {
-                this.inventory = Bukkit.createInventory(null, guiWindow.getSize(), guiName);
+                this.inventory = wolfyUtilities.getNmsUtil().getInventoryUtil().createGUIInventory(guiHandler, guiWindow, guiWindow.getSize(), guiName);
             } else {
-                this.inventory = Bukkit.createInventory(null, guiWindow.getInventoryType(), guiName);
+                this.inventory = wolfyUtilities.getNmsUtil().getInventoryUtil().createGUIInventory(guiHandler, guiWindow, guiWindow.getInventoryType(), guiName);
             }
         } else {
             this.inventory = guiWindow.getInventory(guiHandler);
@@ -109,7 +109,7 @@ public class GuiUpdate<C extends CustomCache> {
     /*
     Sets a Button object to the specific slot.
      */
-    public void setButton(int slot, @Nonnull Button button) {
+    public void setButton(int slot, @Nonnull Button<C> button) {
         if (button != null) {
             guiHandler.setButton(guiWindow, slot, button.getId());
             renderButton(button, guiHandler, player, slot, guiHandler.isHelpEnabled());

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/GuiUpdate.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/GuiUpdate.java
@@ -3,12 +3,11 @@ package me.wolfyscript.utilities.api.inventory.gui;
 import me.wolfyscript.utilities.api.WolfyUtilities;
 import me.wolfyscript.utilities.api.inventory.gui.button.Button;
 import me.wolfyscript.utilities.api.inventory.gui.cache.CustomCache;
+import me.wolfyscript.utilities.api.nms.inventory.GUIInventory;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryInteractEvent;
-import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.inventory.Inventory;
-import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
 
 import javax.annotation.Nonnull;
@@ -26,14 +25,16 @@ public class GuiUpdate<C extends CustomCache> {
     private final Inventory queueInventory;
     private final GuiWindow<C> guiWindow;
 
-    public GuiUpdate(GuiHandler<C> guiHandler, GuiWindow<C> guiWindow) {
+    public GuiUpdate(GUIInventory<C> inventory, GuiHandler<C> guiHandler, GuiWindow<C> guiWindow) {
         this.guiHandler = guiHandler;
         this.inventoryAPI = guiHandler.getInvAPI();
         this.wolfyUtilities = guiHandler.getApi();
         this.player = guiHandler.getPlayer();
         this.guiWindow = guiWindow;
         this.queueInventory = Bukkit.createInventory(null, 54, "");
-        if (!guiWindow.hasCachedInventory(guiHandler)) {
+        if (inventory != null) {
+            this.inventory = inventory;
+        } else {
             String guiName = guiWindow.getInventoryName();
             guiName = guiName.replace("%plugin.version%", wolfyUtilities.getPlugin().getDescription().getVersion()).replace("%plugin.author%", wolfyUtilities.getPlugin().getDescription().getAuthors().toString()).replace("%plugin.name%", wolfyUtilities.getPlugin().getDescription().getName());
             if (guiWindow.getInventoryType() == null) {
@@ -41,8 +42,6 @@ public class GuiUpdate<C extends CustomCache> {
             } else {
                 this.inventory = wolfyUtilities.getNmsUtil().getInventoryUtil().createGUIInventory(guiHandler, guiWindow, guiWindow.getInventoryType(), guiName);
             }
-        } else {
-            this.inventory = guiWindow.getInventory(guiHandler);
         }
     }
 
@@ -140,14 +139,6 @@ public class GuiUpdate<C extends CustomCache> {
 
     public Inventory getInventory() {
         return inventory;
-    }
-
-    public Inventory createInventory(InventoryHolder owner, int size) {
-        return Bukkit.createInventory(owner, size, guiWindow.getInventoryName());
-    }
-
-    public Inventory createInventory(InventoryHolder owner, InventoryType type) {
-        return Bukkit.createInventory(owner, type, guiWindow.getInventoryName());
     }
 
     public void applyChanges() {

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/GuiWindow.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/GuiWindow.java
@@ -158,9 +158,9 @@ public abstract class GuiWindow<C extends CustomCache> implements Listener {
         setCachedInventorie(guiHandler, guiUpdate.getInventory());
         if (openInventory) {
             Bukkit.getScheduler().runTask(getAPI().getPlugin(), () -> {
-                guiHandler.setChangingInv(true);
+                guiHandler.setSwitchWindow(true);
                 guiHandler.getPlayer().openInventory(guiUpdate.getInventory());
-                guiHandler.setChangingInv(false);
+                guiHandler.setSwitchWindow(false);
             });
         }
     }
@@ -205,7 +205,7 @@ public abstract class GuiWindow<C extends CustomCache> implements Listener {
     }
 
     public void reloadInv(GuiHandler<C> guiHandler) {
-        guiHandler.reloadInv(guiHandler.getCurrentInv().getNamespacedKey());
+        guiHandler.reloadWindow(guiHandler.getWindow().getNamespacedKey());
     }
 
     /*

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/InventoryAPI.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/InventoryAPI.java
@@ -213,20 +213,13 @@ public class InventoryAPI<C extends CustomCache> implements Listener {
         if (hasGuiHandler((Player) event.getWhoClicked())) {
             Inventory inventory = event.getInventory();
             if (inventory instanceof GUIInventory && ((GUIInventory<?>) inventory).getGuiHandler().getInvAPI().equals(this)) {
-                GUIInventory<C> guiInventory = (GUIInventory<C>) inventory;
-                GuiHandler<C> guiHandler = guiInventory.getGuiHandler();
-
+                GuiHandler<C> guiHandler = ((GUIInventory<C>) inventory).getGuiHandler();
                 if (event.getRawSlots().parallelStream().anyMatch(rawSlot -> !Objects.equals(event.getView().getInventory(rawSlot), event.getView().getTopInventory()))) {
                     event.setCancelled(true);
                     return;
                 }
                 GuiWindow<C> guiWindow = guiHandler.getWindow();
                 if (guiWindow != null) {
-                    /*
-                System.out.println("Clicked in "+guiWindow);
-                System.out.println("    Slots: "+event.getInventorySlots());
-                System.out.println("    Type: "+event.getType());
-                //*/
                     GuiItemDragEvent guiItemDragEvent = new GuiItemDragEvent(guiHandler, event);
                     Bukkit.getPluginManager().callEvent(guiItemDragEvent);
                     if (guiItemDragEvent.isCancelled()) {

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/button/Button.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/button/Button.java
@@ -55,7 +55,7 @@ public abstract class Button<C extends CustomCache> {
     protected void applyItem(GuiHandler<C> guiHandler, Player player, Inventory inventory, ButtonState<C> state, int slot, boolean help) {
         ItemStack item = state.getIcon();
         HashMap<String, Object> values = new HashMap<>();
-        values.put("%wolfyutilities.help%", guiHandler.getCurrentInv().getHelpInformation());
+        values.put("%wolfyutilities.help%", guiHandler.getWindow().getHelpInformation());
         values.put("%plugin.version%", guiHandler.getApi().getPlugin().getDescription().getVersion());
         if (state.getRenderAction() != null) {
             item = state.getRenderAction().render(values, guiHandler, player, item, slot, help);

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/button/ButtonState.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/button/ButtonState.java
@@ -3,7 +3,6 @@ package me.wolfyscript.utilities.api.inventory.gui.button;
 import me.wolfyscript.utilities.api.WolfyUtilities;
 import me.wolfyscript.utilities.api.inventory.gui.GuiWindow;
 import me.wolfyscript.utilities.api.inventory.gui.cache.CustomCache;
-import me.wolfyscript.utilities.util.NamespacedKey;
 import me.wolfyscript.utilities.util.inventory.ItemUtils;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
@@ -21,7 +20,6 @@ import java.util.List;
  */
 public class ButtonState<C extends CustomCache> {
 
-    private NamespacedKey namespacedKey;
     private String clusterID;
     private String key;
     private final ItemStack presetIcon;
@@ -255,7 +253,7 @@ public class ButtonState<C extends CustomCache> {
 
     public void init(GuiWindow<C> window) {
         if (key != null && !key.isEmpty()) {
-            String path = "inventories." + window.getNamespacedKey().getNamespace() + "." + window.getNamespacedKey() + ".items." + key;
+            String path = "inventories." + window.getCluster().getId() + "." + window.getNamespacedKey().getKey() + ".items." + key;
             if (clusterID != null && !clusterID.isEmpty()) {
                 path = "inventories." + clusterID + ".global_items." + key;
             }

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/button/buttons/ChatInputButton.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/button/buttons/ChatInputButton.java
@@ -134,8 +134,8 @@ public class ChatInputButton<C extends CustomCache> extends DummyButton<C> {
         } else if (clickData != null) {
             guiHandler.getApi().getChat().sendActionMessage(guiHandler.getPlayer(), clickData);
         } else {
-            if (guiHandler.getCurrentInv() != null) {
-                chat.sendPlayerMessage(player, "$inventories." + guiHandler.getCurrentGuiCluster() + "." + guiHandler.getCurrentInv().getNamespacedKey().getNamespace() + ".items." + getId() + ".message$");
+            if (guiHandler.getWindow() != null) {
+                chat.sendPlayerMessage(player, "$inventories." + guiHandler.getCluster() + "." + guiHandler.getWindow().getNamespacedKey().getNamespace() + ".items." + getId() + ".message$");
             }
         }
         guiHandler.close();

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/cache/CustomCache.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/cache/CustomCache.java
@@ -3,20 +3,23 @@ package me.wolfyscript.utilities.api.inventory.gui.cache;
 import me.wolfyscript.utilities.api.inventory.gui.GuiWindow;
 import me.wolfyscript.utilities.util.NamespacedKey;
 
+import java.util.HashMap;
 import java.util.TreeMap;
 
 public class CustomCache extends TreeMap<String, Object> {
 
+    private final HashMap<GuiWindow<?>, TreeMap<Integer, String>> cachedButtons;
+
     private final TreeMap<NamespacedKey, Object> windows;
 
     public CustomCache() {
+        this.cachedButtons = new HashMap<>();
         windows = new TreeMap<>();
     }
 
     public TreeMap<String, Object> getWindowCache(GuiWindow<?> guiWindow) {
         if (!hasWindowCache(guiWindow)) {
             setWindowCache(guiWindow, new TreeMap<>());
-            setButtons(guiWindow, new TreeMap<>());
         }
         return (TreeMap<String, Object>) windows.get(guiWindow.getNamespacedKey());
     }
@@ -29,11 +32,13 @@ public class CustomCache extends TreeMap<String, Object> {
         windows.put(guiWindow.getNamespacedKey(), cache);
     }
 
-    public TreeMap<Integer, String> getButtons(GuiWindow<?> guiWindow) {
-        return ((TreeMap<Integer, String>) getWindowCache(guiWindow).getOrDefault("buttons", new TreeMap<Integer, String>()));
+    public TreeMap<Integer, String> getButtons(GuiWindow<?> window) {
+        return cachedButtons.getOrDefault(window, new TreeMap<>());
     }
 
-    public void setButtons(GuiWindow<?> guiWindow, TreeMap<Integer, String> buttons) {
-        getWindowCache(guiWindow).put("buttons", buttons);
+    public void setButton(GuiWindow<?> window, int slot, String buttonID) {
+        TreeMap<Integer, String> buttons = getButtons(window);
+        buttons.put(slot, buttonID);
+        cachedButtons.put(window, buttons);
     }
 }

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/events/GuiItemDragEvent.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/events/GuiItemDragEvent.java
@@ -37,7 +37,7 @@ public class GuiItemDragEvent extends Event implements Cancellable {
         this.guiHandler = guiHandler;
         this.player = guiHandler.getPlayer();
         this.wolfyUtilities = guiHandler.getApi();
-        this.guiWindow = guiHandler.getCurrentInv();
+        this.guiWindow = guiHandler.getWindow();
         type = event.getType();
         addedItems = event.getNewItems();
         containerSlots = event.getInventorySlots();

--- a/core/src/main/java/me/wolfyscript/utilities/api/nms/InventoryUtil.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/nms/InventoryUtil.java
@@ -1,0 +1,28 @@
+package me.wolfyscript.utilities.api.nms;
+
+import me.wolfyscript.utilities.api.inventory.gui.GuiHandler;
+import me.wolfyscript.utilities.api.inventory.gui.GuiWindow;
+import me.wolfyscript.utilities.api.inventory.gui.cache.CustomCache;
+import me.wolfyscript.utilities.api.nms.inventory.GUIInventory;
+import org.bukkit.event.inventory.InventoryType;
+
+public abstract class InventoryUtil {
+
+    private final NMSUtil nmsUtil;
+
+    protected InventoryUtil(NMSUtil nmsUtil) {
+        this.nmsUtil = nmsUtil;
+    }
+
+    public NMSUtil getNmsUtil() {
+        return nmsUtil;
+    }
+
+    public abstract <C extends CustomCache> GUIInventory<C> createGUIInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryType type);
+
+    public abstract <C extends CustomCache> GUIInventory<C> createGUIInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryType type, String title);
+
+    public abstract <C extends CustomCache> GUIInventory<C> createGUIInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, int size);
+
+    public abstract <C extends CustomCache> GUIInventory<C> createGUIInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, int size, String title);
+}

--- a/core/src/main/java/me/wolfyscript/utilities/api/nms/NMSUtil.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/nms/NMSUtil.java
@@ -31,20 +31,6 @@ public abstract class NMSUtil {
      */
     public static NMSUtil create(WolfyUtilities wolfyUtilities) {
         String version = Reflection.getVersion();
-        /*
-        try {
-            String className = NMSUtil.class.getPackage().getName() + '.' + version + ".VersionedNMS";
-            Class<?> versioningType = Class.forName(className);
-            if (VersionedNMS.class.isAssignableFrom(versioningType)) {
-                return ((VersionedNMS) versioningType.getDeclaredConstructor().newInstance()).createNMSUtils(plugin);
-            }
-        } catch (ClassNotFoundException ex) {
-            // fallthrough, does not exist
-        } catch (ReflectiveOperationException ex) {
-            ex.printStackTrace();
-        }
-
-         */
 
         try {
             String className = NMSUtil.class.getPackage().getName() + '.' + version + ".NMSEntry";
@@ -66,6 +52,8 @@ public abstract class NMSUtil {
     public abstract BlockUtil getBlockUtil();
 
     public abstract ItemUtil getItemUtil();
+
+    public abstract InventoryUtil getInventoryUtil();
 
 
 }

--- a/core/src/main/java/me/wolfyscript/utilities/api/nms/inventory/GUIInventory.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/nms/inventory/GUIInventory.java
@@ -1,0 +1,13 @@
+package me.wolfyscript.utilities.api.nms.inventory;
+
+import me.wolfyscript.utilities.api.inventory.gui.GuiHandler;
+import me.wolfyscript.utilities.api.inventory.gui.GuiWindow;
+import me.wolfyscript.utilities.api.inventory.gui.cache.CustomCache;
+import org.bukkit.inventory.Inventory;
+
+public interface GUIInventory<C extends CustomCache> extends Inventory {
+
+    GuiWindow<C> getWindow();
+
+    GuiHandler<C> getGuiHandler();
+}

--- a/core/src/main/java/me/wolfyscript/utilities/util/NamespacedKey.java
+++ b/core/src/main/java/me/wolfyscript/utilities/util/NamespacedKey.java
@@ -68,7 +68,14 @@ public class NamespacedKey implements Comparable<NamespacedKey> {
     }
 
     public String toString() {
-        return this.namespace + ":" + this.key;
+        return toString(":");
+    }
+
+    public String toString(String split) {
+        if (split == null || split.isEmpty()) {
+            split = ":";
+        }
+        return this.namespace + split + this.key;
     }
 
     @Override

--- a/nmsutil-v1_14_R1/src/main/java/me/wolfyscript/utilities/api/nms/v1_14_R1/InventoryUtilImpl.java
+++ b/nmsutil-v1_14_R1/src/main/java/me/wolfyscript/utilities/api/nms/v1_14_R1/InventoryUtilImpl.java
@@ -17,21 +17,21 @@ public class InventoryUtilImpl extends InventoryUtil {
 
     @Override
     public <C extends CustomCache> GUIInventory<C> createGUIInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryType type) {
-        return GUIInventoryCreator.INSTANCE.createInventory(guiHandler, window, guiHandler, type);
+        return GUIInventoryCreator.INSTANCE.createInventory(guiHandler, window, null, type);
     }
 
     @Override
     public <C extends CustomCache> GUIInventory<C> createGUIInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryType type, String title) {
-        return GUIInventoryCreator.INSTANCE.createInventory(guiHandler, window, guiHandler, type, title);
+        return GUIInventoryCreator.INSTANCE.createInventory(guiHandler, window, null, type, title);
     }
 
     @Override
     public <C extends CustomCache> GUIInventory<C> createGUIInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, int size) {
-        return GUIInventoryCreator.INSTANCE.createInventory(guiHandler, window, guiHandler, size);
+        return GUIInventoryCreator.INSTANCE.createInventory(guiHandler, window, null, size);
     }
 
     @Override
     public <C extends CustomCache> GUIInventory<C> createGUIInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, int size, String title) {
-        return GUIInventoryCreator.INSTANCE.createInventory(guiHandler, window, guiHandler, size, title);
+        return GUIInventoryCreator.INSTANCE.createInventory(guiHandler, window, null, size, title);
     }
 }

--- a/nmsutil-v1_14_R1/src/main/java/me/wolfyscript/utilities/api/nms/v1_14_R1/InventoryUtilImpl.java
+++ b/nmsutil-v1_14_R1/src/main/java/me/wolfyscript/utilities/api/nms/v1_14_R1/InventoryUtilImpl.java
@@ -1,0 +1,37 @@
+package me.wolfyscript.utilities.api.nms.v1_14_R1;
+
+import me.wolfyscript.utilities.api.inventory.gui.GuiHandler;
+import me.wolfyscript.utilities.api.inventory.gui.GuiWindow;
+import me.wolfyscript.utilities.api.inventory.gui.cache.CustomCache;
+import me.wolfyscript.utilities.api.nms.InventoryUtil;
+import me.wolfyscript.utilities.api.nms.NMSUtil;
+import me.wolfyscript.utilities.api.nms.inventory.GUIInventory;
+import me.wolfyscript.utilities.api.nms.v1_14_R1.inventory.util.GUIInventoryCreator;
+import org.bukkit.event.inventory.InventoryType;
+
+public class InventoryUtilImpl extends InventoryUtil {
+
+    protected InventoryUtilImpl(NMSUtil nmsUtil) {
+        super(nmsUtil);
+    }
+
+    @Override
+    public <C extends CustomCache> GUIInventory<C> createGUIInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryType type) {
+        return GUIInventoryCreator.INSTANCE.createInventory(guiHandler, window, guiHandler, type);
+    }
+
+    @Override
+    public <C extends CustomCache> GUIInventory<C> createGUIInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryType type, String title) {
+        return GUIInventoryCreator.INSTANCE.createInventory(guiHandler, window, guiHandler, type, title);
+    }
+
+    @Override
+    public <C extends CustomCache> GUIInventory<C> createGUIInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, int size) {
+        return GUIInventoryCreator.INSTANCE.createInventory(guiHandler, window, guiHandler, size);
+    }
+
+    @Override
+    public <C extends CustomCache> GUIInventory<C> createGUIInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, int size, String title) {
+        return GUIInventoryCreator.INSTANCE.createInventory(guiHandler, window, guiHandler, size, title);
+    }
+}

--- a/nmsutil-v1_14_R1/src/main/java/me/wolfyscript/utilities/api/nms/v1_14_R1/NMSEntry.java
+++ b/nmsutil-v1_14_R1/src/main/java/me/wolfyscript/utilities/api/nms/v1_14_R1/NMSEntry.java
@@ -11,6 +11,7 @@ public class NMSEntry extends NMSUtil {
 
     private final BlockUtil blockUtil;
     private final ItemUtil itemUtil;
+    private final InventoryUtil inventoryUtil;
 
     /**
      * The class that implements this NMSUtil needs to have a constructor with just the {@link Plugin} parameter.
@@ -21,6 +22,7 @@ public class NMSEntry extends NMSUtil {
         super(wolfyUtilities);
         this.blockUtil = new BlockUtilImpl(this);
         this.itemUtil = new ItemUtilImpl(this);
+        this.inventoryUtil = new InventoryUtilImpl(this);
     }
 
     @Override
@@ -35,6 +37,6 @@ public class NMSEntry extends NMSUtil {
 
     @Override
     public InventoryUtil getInventoryUtil() {
-        return null;
+        return inventoryUtil;
     }
 }

--- a/nmsutil-v1_14_R1/src/main/java/me/wolfyscript/utilities/api/nms/v1_14_R1/NMSEntry.java
+++ b/nmsutil-v1_14_R1/src/main/java/me/wolfyscript/utilities/api/nms/v1_14_R1/NMSEntry.java
@@ -2,6 +2,7 @@ package me.wolfyscript.utilities.api.nms.v1_14_R1;
 
 import me.wolfyscript.utilities.api.WolfyUtilities;
 import me.wolfyscript.utilities.api.nms.BlockUtil;
+import me.wolfyscript.utilities.api.nms.InventoryUtil;
 import me.wolfyscript.utilities.api.nms.ItemUtil;
 import me.wolfyscript.utilities.api.nms.NMSUtil;
 import org.bukkit.plugin.Plugin;
@@ -32,5 +33,8 @@ public class NMSEntry extends NMSUtil {
         return itemUtil;
     }
 
-
+    @Override
+    public InventoryUtil getInventoryUtil() {
+        return null;
+    }
 }

--- a/nmsutil-v1_14_R1/src/main/java/me/wolfyscript/utilities/api/nms/v1_14_R1/inventory/GUIInventoryBrewer.java
+++ b/nmsutil-v1_14_R1/src/main/java/me/wolfyscript/utilities/api/nms/v1_14_R1/inventory/GUIInventoryBrewer.java
@@ -1,0 +1,30 @@
+package me.wolfyscript.utilities.api.nms.v1_14_R1.inventory;
+
+import me.wolfyscript.utilities.api.inventory.gui.GuiHandler;
+import me.wolfyscript.utilities.api.inventory.gui.GuiWindow;
+import me.wolfyscript.utilities.api.inventory.gui.cache.CustomCache;
+import me.wolfyscript.utilities.api.nms.inventory.GUIInventory;
+import net.minecraft.server.v1_14_R1.IInventory;
+import org.bukkit.craftbukkit.v1_14_R1.inventory.CraftInventoryBrewer;
+
+public class GUIInventoryBrewer<C extends CustomCache> extends CraftInventoryBrewer implements GUIInventory<C> {
+
+    private final GuiWindow<C> window;
+    private final GuiHandler<C> guiHandler;
+
+    public GUIInventoryBrewer(GuiHandler<C> guiHandler, GuiWindow<C> window, IInventory inventory) {
+        super(inventory);
+        this.guiHandler = guiHandler;
+        this.window = window;
+    }
+
+    @Override
+    public GuiWindow<C> getWindow() {
+        return window;
+    }
+
+    @Override
+    public GuiHandler<C> getGuiHandler() {
+        return guiHandler;
+    }
+}

--- a/nmsutil-v1_14_R1/src/main/java/me/wolfyscript/utilities/api/nms/v1_14_R1/inventory/GUIInventoryCustom.java
+++ b/nmsutil-v1_14_R1/src/main/java/me/wolfyscript/utilities/api/nms/v1_14_R1/inventory/GUIInventoryCustom.java
@@ -1,0 +1,49 @@
+package me.wolfyscript.utilities.api.nms.v1_14_R1.inventory;
+
+import me.wolfyscript.utilities.api.inventory.gui.GuiHandler;
+import me.wolfyscript.utilities.api.inventory.gui.GuiWindow;
+import me.wolfyscript.utilities.api.inventory.gui.cache.CustomCache;
+import me.wolfyscript.utilities.api.nms.inventory.GUIInventory;
+import org.bukkit.craftbukkit.v1_14_R1.inventory.CraftInventoryCustom;
+import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.inventory.InventoryHolder;
+
+public class GUIInventoryCustom<C extends CustomCache> extends CraftInventoryCustom implements GUIInventory<C> {
+
+    private final GuiWindow<C> window;
+    private final GuiHandler<C> guiHandler;
+
+    public GUIInventoryCustom(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder owner, InventoryType type) {
+        super(owner, type);
+        this.guiHandler = guiHandler;
+        this.window = window;
+    }
+
+    public GUIInventoryCustom(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder owner, InventoryType type, String title) {
+        super(owner, type, title);
+        this.guiHandler = guiHandler;
+        this.window = window;
+    }
+
+    public GUIInventoryCustom(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder owner, int size) {
+        super(owner, size);
+        this.guiHandler = guiHandler;
+        this.window = window;
+    }
+
+    public GUIInventoryCustom(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder owner, int size, String title) {
+        super(owner, size, title);
+        this.guiHandler = guiHandler;
+        this.window = window;
+    }
+
+    @Override
+    public GuiWindow<C> getWindow() {
+        return this.window;
+    }
+
+    @Override
+    public GuiHandler<C> getGuiHandler() {
+        return guiHandler;
+    }
+}

--- a/nmsutil-v1_14_R1/src/main/java/me/wolfyscript/utilities/api/nms/v1_14_R1/inventory/GUIInventoryFurnace.java
+++ b/nmsutil-v1_14_R1/src/main/java/me/wolfyscript/utilities/api/nms/v1_14_R1/inventory/GUIInventoryFurnace.java
@@ -1,0 +1,31 @@
+package me.wolfyscript.utilities.api.nms.v1_14_R1.inventory;
+
+import me.wolfyscript.utilities.api.inventory.gui.GuiHandler;
+import me.wolfyscript.utilities.api.inventory.gui.GuiWindow;
+import me.wolfyscript.utilities.api.inventory.gui.cache.CustomCache;
+import me.wolfyscript.utilities.api.nms.inventory.GUIInventory;
+import net.minecraft.server.v1_14_R1.TileEntityFurnace;
+import org.bukkit.craftbukkit.v1_14_R1.inventory.CraftInventoryFurnace;
+
+
+public class GUIInventoryFurnace<C extends CustomCache> extends CraftInventoryFurnace implements GUIInventory<C> {
+
+    private final GuiWindow<C> window;
+    private final GuiHandler<C> guiHandler;
+
+    public GUIInventoryFurnace(GuiHandler<C> guiHandler, GuiWindow<C> window, TileEntityFurnace inventory) {
+        super(inventory);
+        this.guiHandler = guiHandler;
+        this.window = window;
+    }
+
+    @Override
+    public GuiWindow<C> getWindow() {
+        return window;
+    }
+
+    @Override
+    public GuiHandler<C> getGuiHandler() {
+        return guiHandler;
+    }
+}

--- a/nmsutil-v1_14_R1/src/main/java/me/wolfyscript/utilities/api/nms/v1_14_R1/inventory/GUIInventoryImpl.java
+++ b/nmsutil-v1_14_R1/src/main/java/me/wolfyscript/utilities/api/nms/v1_14_R1/inventory/GUIInventoryImpl.java
@@ -1,0 +1,30 @@
+package me.wolfyscript.utilities.api.nms.v1_14_R1.inventory;
+
+import me.wolfyscript.utilities.api.inventory.gui.GuiHandler;
+import me.wolfyscript.utilities.api.inventory.gui.GuiWindow;
+import me.wolfyscript.utilities.api.inventory.gui.cache.CustomCache;
+import me.wolfyscript.utilities.api.nms.inventory.GUIInventory;
+import net.minecraft.server.v1_14_R1.IInventory;
+import org.bukkit.craftbukkit.v1_14_R1.inventory.CraftInventory;
+
+public class GUIInventoryImpl<C extends CustomCache> extends CraftInventory implements GUIInventory<C> {
+
+    private final GuiWindow<C> window;
+    private final GuiHandler<C> guiHandler;
+
+    public GUIInventoryImpl(GuiHandler<C> guiHandler, GuiWindow<C> window, IInventory inventory) {
+        super(inventory);
+        this.guiHandler = guiHandler;
+        this.window = window;
+    }
+
+    @Override
+    public GuiWindow<C> getWindow() {
+        return window;
+    }
+
+    @Override
+    public GuiHandler<C> getGuiHandler() {
+        return guiHandler;
+    }
+}

--- a/nmsutil-v1_14_R1/src/main/java/me/wolfyscript/utilities/api/nms/v1_14_R1/inventory/util/GUICustomInventoryConverter.java
+++ b/nmsutil-v1_14_R1/src/main/java/me/wolfyscript/utilities/api/nms/v1_14_R1/inventory/util/GUICustomInventoryConverter.java
@@ -1,0 +1,33 @@
+package me.wolfyscript.utilities.api.nms.v1_14_R1.inventory.util;
+
+import me.wolfyscript.utilities.api.inventory.gui.GuiHandler;
+import me.wolfyscript.utilities.api.inventory.gui.GuiWindow;
+import me.wolfyscript.utilities.api.inventory.gui.cache.CustomCache;
+import me.wolfyscript.utilities.api.nms.inventory.GUIInventory;
+import me.wolfyscript.utilities.api.nms.v1_14_R1.inventory.GUIInventoryCustom;
+import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.inventory.InventoryHolder;
+
+public class GUICustomInventoryConverter implements GUIInventoryCreator.InventoryConverter {
+
+    public GUICustomInventoryConverter() {
+    }
+
+    @Override
+    public <C extends CustomCache> GUIInventory<C> createInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder holder, InventoryType type) {
+        return new GUIInventoryCustom<>(guiHandler, window, holder, type);
+    }
+
+    @Override
+    public <C extends CustomCache> GUIInventory<C> createInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder holder, InventoryType type, String title) {
+        return new GUIInventoryCustom<>(guiHandler, window, holder, type, title);
+    }
+
+    public <C extends CustomCache> GUIInventory<C> createInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder owner, int size) {
+        return new GUIInventoryCustom<>(guiHandler, window, owner, size);
+    }
+
+    public <C extends CustomCache> GUIInventory<C> createInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder owner, int size, String title) {
+        return new GUIInventoryCustom<>(guiHandler, window, owner, size, title);
+    }
+}

--- a/nmsutil-v1_14_R1/src/main/java/me/wolfyscript/utilities/api/nms/v1_14_R1/inventory/util/GUIInventoryCreator.java
+++ b/nmsutil-v1_14_R1/src/main/java/me/wolfyscript/utilities/api/nms/v1_14_R1/inventory/util/GUIInventoryCreator.java
@@ -1,0 +1,69 @@
+package me.wolfyscript.utilities.api.nms.v1_14_R1.inventory.util;
+
+import me.wolfyscript.utilities.api.inventory.gui.GuiHandler;
+import me.wolfyscript.utilities.api.inventory.gui.GuiWindow;
+import me.wolfyscript.utilities.api.inventory.gui.cache.CustomCache;
+import me.wolfyscript.utilities.api.nms.inventory.GUIInventory;
+import org.apache.commons.lang.Validate;
+import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.inventory.InventoryHolder;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class GUIInventoryCreator {
+
+    public static final GUIInventoryCreator INSTANCE = new GUIInventoryCreator();
+    private final GUICustomInventoryConverter DEFAULT_CONVERTER = new GUICustomInventoryConverter();
+    private final Map<InventoryType, InventoryConverter> converterMap = new HashMap<>();
+
+    private GUIInventoryCreator() {
+        this.converterMap.put(InventoryType.CHEST, this.DEFAULT_CONVERTER);
+        this.converterMap.put(InventoryType.DISPENSER, new GUITileInventoryConverter.Dispenser());
+        this.converterMap.put(InventoryType.DROPPER, new GUITileInventoryConverter.Dropper());
+        this.converterMap.put(InventoryType.FURNACE, new GUITileInventoryConverter.Furnace());
+        this.converterMap.put(InventoryType.WORKBENCH, this.DEFAULT_CONVERTER);
+        this.converterMap.put(InventoryType.ENCHANTING, this.DEFAULT_CONVERTER);
+        this.converterMap.put(InventoryType.BREWING, new GUITileInventoryConverter.BrewingStand());
+        this.converterMap.put(InventoryType.PLAYER, this.DEFAULT_CONVERTER);
+        this.converterMap.put(InventoryType.MERCHANT, this.DEFAULT_CONVERTER);
+        this.converterMap.put(InventoryType.ENDER_CHEST, this.DEFAULT_CONVERTER);
+        this.converterMap.put(InventoryType.ANVIL, this.DEFAULT_CONVERTER);
+        this.converterMap.put(InventoryType.BEACON, this.DEFAULT_CONVERTER);
+        this.converterMap.put(InventoryType.HOPPER, new GUITileInventoryConverter.Hopper());
+        this.converterMap.put(InventoryType.SHULKER_BOX, this.DEFAULT_CONVERTER);
+        this.converterMap.put(InventoryType.BARREL, this.DEFAULT_CONVERTER);
+        this.converterMap.put(InventoryType.BLAST_FURNACE, new GUITileInventoryConverter.BlastFurnace());
+        this.converterMap.put(InventoryType.LECTERN, new GUITileInventoryConverter.Lectern());
+        this.converterMap.put(InventoryType.SMOKER, new GUITileInventoryConverter.Smoker());
+        this.converterMap.put(InventoryType.LOOM, this.DEFAULT_CONVERTER);
+        this.converterMap.put(InventoryType.CARTOGRAPHY, this.DEFAULT_CONVERTER);
+        this.converterMap.put(InventoryType.GRINDSTONE, this.DEFAULT_CONVERTER);
+        this.converterMap.put(InventoryType.STONECUTTER, this.DEFAULT_CONVERTER);
+    }
+
+    public <C extends CustomCache> GUIInventory<C> createInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder holder, InventoryType type) {
+        Validate.isTrue(this.converterMap.containsKey(type), "Cannot create GUI inventory of type ", type);
+        return this.converterMap.get(type).createInventory(guiHandler, window, holder, type);
+    }
+
+    public <C extends CustomCache> GUIInventory<C> createInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder holder, InventoryType type, String title) {
+        Validate.isTrue(this.converterMap.containsKey(type), "Cannot create GUI inventory of type ", type);
+        return this.converterMap.get(type).createInventory(guiHandler, window, holder, type, title);
+    }
+
+    public <C extends CustomCache> GUIInventory<C> createInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder holder, int size) {
+        return this.DEFAULT_CONVERTER.createInventory(guiHandler, window, holder, size);
+    }
+
+    public <C extends CustomCache> GUIInventory<C> createInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder holder, int size, String title) {
+        return this.DEFAULT_CONVERTER.createInventory(guiHandler, window, holder, size, title);
+    }
+
+    public interface InventoryConverter {
+
+        <C extends CustomCache> GUIInventory<C> createInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder holder, InventoryType type);
+
+        <C extends CustomCache> GUIInventory<C> createInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder holder, InventoryType type, String title);
+    }
+}

--- a/nmsutil-v1_14_R1/src/main/java/me/wolfyscript/utilities/api/nms/v1_14_R1/inventory/util/GUITileInventoryConverter.java
+++ b/nmsutil-v1_14_R1/src/main/java/me/wolfyscript/utilities/api/nms/v1_14_R1/inventory/util/GUITileInventoryConverter.java
@@ -1,0 +1,126 @@
+package me.wolfyscript.utilities.api.nms.v1_14_R1.inventory.util;
+
+import me.wolfyscript.utilities.api.inventory.gui.GuiHandler;
+import me.wolfyscript.utilities.api.inventory.gui.GuiWindow;
+import me.wolfyscript.utilities.api.inventory.gui.cache.CustomCache;
+import me.wolfyscript.utilities.api.nms.inventory.GUIInventory;
+import me.wolfyscript.utilities.api.nms.v1_14_R1.inventory.GUIInventoryBrewer;
+import me.wolfyscript.utilities.api.nms.v1_14_R1.inventory.GUIInventoryFurnace;
+import me.wolfyscript.utilities.api.nms.v1_14_R1.inventory.GUIInventoryImpl;
+import net.minecraft.server.v1_14_R1.*;
+import org.bukkit.craftbukkit.v1_14_R1.util.CraftChatMessage;
+import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.inventory.InventoryHolder;
+
+public abstract class GUITileInventoryConverter implements GUIInventoryCreator.InventoryConverter {
+
+    public GUITileInventoryConverter() {
+    }
+
+    public abstract IInventory getTileEntity();
+
+    @Override
+    public <C extends CustomCache> GUIInventory<C> createInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder holder, InventoryType type) {
+        return this.getInventory(guiHandler, window, this.getTileEntity());
+    }
+
+    @Override
+    public <C extends CustomCache> GUIInventory<C> createInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder holder, InventoryType type, String title) {
+        IInventory te = this.getTileEntity();
+        if (te instanceof TileEntityLootable) {
+            ((TileEntityLootable) te).setCustomName(CraftChatMessage.fromStringOrNull(title));
+        }
+        return this.getInventory(guiHandler, window, te);
+    }
+
+    public <C extends CustomCache> GUIInventory<C> getInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, IInventory tileEntity) {
+        return new GUIInventoryImpl<>(guiHandler, window, tileEntity);
+    }
+
+    //---------------------------Sub-Classes------------------------------------
+
+    public static class BlastFurnace extends GUITileInventoryConverter {
+        @Override
+        public IInventory getTileEntity() {
+            return new TileEntityBlastFurnace();
+        }
+    }
+
+    public static class BrewingStand extends GUITileInventoryConverter {
+        @Override
+        public IInventory getTileEntity() {
+            return new TileEntityBrewingStand();
+        }
+
+        @Override
+        public <C extends CustomCache> GUIInventory<C> createInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder holder, InventoryType type, String title) {
+            IInventory tileEntity = this.getTileEntity();
+            if (tileEntity instanceof TileEntityBrewingStand) {
+                ((TileEntityBrewingStand) tileEntity).setCustomName(CraftChatMessage.fromStringOrNull(title));
+            }
+            return this.getInventory(guiHandler, window, tileEntity);
+        }
+
+        @Override
+        public <C extends CustomCache> GUIInventory<C> getInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, IInventory tileEntity) {
+            return new GUIInventoryBrewer<>(guiHandler, window, tileEntity);
+        }
+    }
+
+    public static class Dispenser extends GUITileInventoryConverter {
+        @Override
+        public IInventory getTileEntity() {
+            return new TileEntityDispenser();
+        }
+    }
+
+    public static class Dropper extends GUITileInventoryConverter {
+        @Override
+        public IInventory getTileEntity() {
+            return new TileEntityDropper();
+        }
+    }
+
+    public static class Furnace extends GUITileInventoryConverter {
+
+        @Override
+        public IInventory getTileEntity() {
+            TileEntityFurnace furnace = new TileEntityFurnaceFurnace();
+            furnace.setWorld(MinecraftServer.getServer().getWorldServer(DimensionManager.OVERWORLD));
+            return furnace;
+        }
+
+        @Override
+        public <C extends CustomCache> GUIInventory<C> createInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder holder, InventoryType type, String title) {
+            IInventory tileEntity = this.getTileEntity();
+            ((TileEntityFurnace) tileEntity).setCustomName(CraftChatMessage.fromStringOrNull(title));
+            return this.getInventory(guiHandler, window, tileEntity);
+        }
+
+        @Override
+        public <C extends CustomCache> GUIInventory<C> getInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, IInventory tileEntity) {
+            return new GUIInventoryFurnace<>(guiHandler, window, (TileEntityFurnace) tileEntity);
+        }
+    }
+
+    public static class Hopper extends GUITileInventoryConverter {
+        @Override
+        public IInventory getTileEntity() {
+            return new TileEntityHopper();
+        }
+    }
+
+    public static class Lectern extends GUITileInventoryConverter {
+        @Override
+        public IInventory getTileEntity() {
+            return (new TileEntityLectern()).inventory;
+        }
+    }
+
+    public static class Smoker extends GUITileInventoryConverter {
+        @Override
+        public IInventory getTileEntity() {
+            return new TileEntitySmoker();
+        }
+    }
+}

--- a/nmsutil-v1_15_R1/src/main/java/me/wolfyscript/utilities/api/nms/v1_15_R1/InventoryUtilImpl.java
+++ b/nmsutil-v1_15_R1/src/main/java/me/wolfyscript/utilities/api/nms/v1_15_R1/InventoryUtilImpl.java
@@ -17,21 +17,21 @@ public class InventoryUtilImpl extends InventoryUtil {
 
     @Override
     public <C extends CustomCache> GUIInventory<C> createGUIInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryType type) {
-        return GUIInventoryCreator.INSTANCE.createInventory(guiHandler, window, guiHandler, type);
+        return GUIInventoryCreator.INSTANCE.createInventory(guiHandler, window, null, type);
     }
 
     @Override
     public <C extends CustomCache> GUIInventory<C> createGUIInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryType type, String title) {
-        return GUIInventoryCreator.INSTANCE.createInventory(guiHandler, window, guiHandler, type, title);
+        return GUIInventoryCreator.INSTANCE.createInventory(guiHandler, window, null, type, title);
     }
 
     @Override
     public <C extends CustomCache> GUIInventory<C> createGUIInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, int size) {
-        return GUIInventoryCreator.INSTANCE.createInventory(guiHandler, window, guiHandler, size);
+        return GUIInventoryCreator.INSTANCE.createInventory(guiHandler, window, null, size);
     }
 
     @Override
     public <C extends CustomCache> GUIInventory<C> createGUIInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, int size, String title) {
-        return GUIInventoryCreator.INSTANCE.createInventory(guiHandler, window, guiHandler, size, title);
+        return GUIInventoryCreator.INSTANCE.createInventory(guiHandler, window, null, size, title);
     }
 }

--- a/nmsutil-v1_15_R1/src/main/java/me/wolfyscript/utilities/api/nms/v1_15_R1/InventoryUtilImpl.java
+++ b/nmsutil-v1_15_R1/src/main/java/me/wolfyscript/utilities/api/nms/v1_15_R1/InventoryUtilImpl.java
@@ -1,0 +1,37 @@
+package me.wolfyscript.utilities.api.nms.v1_15_R1;
+
+import me.wolfyscript.utilities.api.inventory.gui.GuiHandler;
+import me.wolfyscript.utilities.api.inventory.gui.GuiWindow;
+import me.wolfyscript.utilities.api.inventory.gui.cache.CustomCache;
+import me.wolfyscript.utilities.api.nms.InventoryUtil;
+import me.wolfyscript.utilities.api.nms.NMSUtil;
+import me.wolfyscript.utilities.api.nms.inventory.GUIInventory;
+import me.wolfyscript.utilities.api.nms.v1_15_R1.inventory.util.GUIInventoryCreator;
+import org.bukkit.event.inventory.InventoryType;
+
+public class InventoryUtilImpl extends InventoryUtil {
+
+    protected InventoryUtilImpl(NMSUtil nmsUtil) {
+        super(nmsUtil);
+    }
+
+    @Override
+    public <C extends CustomCache> GUIInventory<C> createGUIInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryType type) {
+        return GUIInventoryCreator.INSTANCE.createInventory(guiHandler, window, guiHandler, type);
+    }
+
+    @Override
+    public <C extends CustomCache> GUIInventory<C> createGUIInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryType type, String title) {
+        return GUIInventoryCreator.INSTANCE.createInventory(guiHandler, window, guiHandler, type, title);
+    }
+
+    @Override
+    public <C extends CustomCache> GUIInventory<C> createGUIInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, int size) {
+        return GUIInventoryCreator.INSTANCE.createInventory(guiHandler, window, guiHandler, size);
+    }
+
+    @Override
+    public <C extends CustomCache> GUIInventory<C> createGUIInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, int size, String title) {
+        return GUIInventoryCreator.INSTANCE.createInventory(guiHandler, window, guiHandler, size, title);
+    }
+}

--- a/nmsutil-v1_15_R1/src/main/java/me/wolfyscript/utilities/api/nms/v1_15_R1/NMSEntry.java
+++ b/nmsutil-v1_15_R1/src/main/java/me/wolfyscript/utilities/api/nms/v1_15_R1/NMSEntry.java
@@ -11,6 +11,7 @@ public class NMSEntry extends NMSUtil {
 
     private final BlockUtil blockUtil;
     private final ItemUtil itemUtil;
+    private final InventoryUtil inventoryUtil;
 
     /**
      * The class that implements this NMSUtil needs to have a constructor with just the {@link Plugin} parameter.
@@ -21,6 +22,7 @@ public class NMSEntry extends NMSUtil {
         super(wolfyUtilities);
         this.blockUtil = new BlockUtilImpl(this);
         this.itemUtil = new ItemUtilImpl(this);
+        this.inventoryUtil = new InventoryUtilImpl(this);
     }
 
     @Override
@@ -35,6 +37,6 @@ public class NMSEntry extends NMSUtil {
 
     @Override
     public InventoryUtil getInventoryUtil() {
-        return null;
+        return inventoryUtil;
     }
 }

--- a/nmsutil-v1_15_R1/src/main/java/me/wolfyscript/utilities/api/nms/v1_15_R1/NMSEntry.java
+++ b/nmsutil-v1_15_R1/src/main/java/me/wolfyscript/utilities/api/nms/v1_15_R1/NMSEntry.java
@@ -2,6 +2,7 @@ package me.wolfyscript.utilities.api.nms.v1_15_R1;
 
 import me.wolfyscript.utilities.api.WolfyUtilities;
 import me.wolfyscript.utilities.api.nms.BlockUtil;
+import me.wolfyscript.utilities.api.nms.InventoryUtil;
 import me.wolfyscript.utilities.api.nms.ItemUtil;
 import me.wolfyscript.utilities.api.nms.NMSUtil;
 import org.bukkit.plugin.Plugin;
@@ -32,5 +33,8 @@ public class NMSEntry extends NMSUtil {
         return itemUtil;
     }
 
-
+    @Override
+    public InventoryUtil getInventoryUtil() {
+        return null;
+    }
 }

--- a/nmsutil-v1_15_R1/src/main/java/me/wolfyscript/utilities/api/nms/v1_15_R1/inventory/GUIInventoryBrewer.java
+++ b/nmsutil-v1_15_R1/src/main/java/me/wolfyscript/utilities/api/nms/v1_15_R1/inventory/GUIInventoryBrewer.java
@@ -1,0 +1,30 @@
+package me.wolfyscript.utilities.api.nms.v1_15_R1.inventory;
+
+import me.wolfyscript.utilities.api.inventory.gui.GuiHandler;
+import me.wolfyscript.utilities.api.inventory.gui.GuiWindow;
+import me.wolfyscript.utilities.api.inventory.gui.cache.CustomCache;
+import me.wolfyscript.utilities.api.nms.inventory.GUIInventory;
+import net.minecraft.server.v1_15_R1.IInventory;
+import org.bukkit.craftbukkit.v1_15_R1.inventory.CraftInventoryBrewer;
+
+public class GUIInventoryBrewer<C extends CustomCache> extends CraftInventoryBrewer implements GUIInventory<C> {
+
+    private final GuiWindow<C> window;
+    private final GuiHandler<C> guiHandler;
+
+    public GUIInventoryBrewer(GuiHandler<C> guiHandler, GuiWindow<C> window, IInventory inventory) {
+        super(inventory);
+        this.guiHandler = guiHandler;
+        this.window = window;
+    }
+
+    @Override
+    public GuiWindow<C> getWindow() {
+        return window;
+    }
+
+    @Override
+    public GuiHandler<C> getGuiHandler() {
+        return guiHandler;
+    }
+}

--- a/nmsutil-v1_15_R1/src/main/java/me/wolfyscript/utilities/api/nms/v1_15_R1/inventory/GUIInventoryCustom.java
+++ b/nmsutil-v1_15_R1/src/main/java/me/wolfyscript/utilities/api/nms/v1_15_R1/inventory/GUIInventoryCustom.java
@@ -1,0 +1,49 @@
+package me.wolfyscript.utilities.api.nms.v1_15_R1.inventory;
+
+import me.wolfyscript.utilities.api.inventory.gui.GuiHandler;
+import me.wolfyscript.utilities.api.inventory.gui.GuiWindow;
+import me.wolfyscript.utilities.api.inventory.gui.cache.CustomCache;
+import me.wolfyscript.utilities.api.nms.inventory.GUIInventory;
+import org.bukkit.craftbukkit.v1_15_R1.inventory.CraftInventoryCustom;
+import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.inventory.InventoryHolder;
+
+public class GUIInventoryCustom<C extends CustomCache> extends CraftInventoryCustom implements GUIInventory<C> {
+
+    private final GuiWindow<C> window;
+    private final GuiHandler<C> guiHandler;
+
+    public GUIInventoryCustom(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder owner, InventoryType type) {
+        super(owner, type);
+        this.guiHandler = guiHandler;
+        this.window = window;
+    }
+
+    public GUIInventoryCustom(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder owner, InventoryType type, String title) {
+        super(owner, type, title);
+        this.guiHandler = guiHandler;
+        this.window = window;
+    }
+
+    public GUIInventoryCustom(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder owner, int size) {
+        super(owner, size);
+        this.guiHandler = guiHandler;
+        this.window = window;
+    }
+
+    public GUIInventoryCustom(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder owner, int size, String title) {
+        super(owner, size, title);
+        this.guiHandler = guiHandler;
+        this.window = window;
+    }
+
+    @Override
+    public GuiWindow<C> getWindow() {
+        return this.window;
+    }
+
+    @Override
+    public GuiHandler<C> getGuiHandler() {
+        return guiHandler;
+    }
+}

--- a/nmsutil-v1_15_R1/src/main/java/me/wolfyscript/utilities/api/nms/v1_15_R1/inventory/GUIInventoryFurnace.java
+++ b/nmsutil-v1_15_R1/src/main/java/me/wolfyscript/utilities/api/nms/v1_15_R1/inventory/GUIInventoryFurnace.java
@@ -1,0 +1,31 @@
+package me.wolfyscript.utilities.api.nms.v1_15_R1.inventory;
+
+import me.wolfyscript.utilities.api.inventory.gui.GuiHandler;
+import me.wolfyscript.utilities.api.inventory.gui.GuiWindow;
+import me.wolfyscript.utilities.api.inventory.gui.cache.CustomCache;
+import me.wolfyscript.utilities.api.nms.inventory.GUIInventory;
+import net.minecraft.server.v1_15_R1.TileEntityFurnace;
+import org.bukkit.craftbukkit.v1_15_R1.inventory.CraftInventoryFurnace;
+
+
+public class GUIInventoryFurnace<C extends CustomCache> extends CraftInventoryFurnace implements GUIInventory<C> {
+
+    private final GuiWindow<C> window;
+    private final GuiHandler<C> guiHandler;
+
+    public GUIInventoryFurnace(GuiHandler<C> guiHandler, GuiWindow<C> window, TileEntityFurnace inventory) {
+        super(inventory);
+        this.guiHandler = guiHandler;
+        this.window = window;
+    }
+
+    @Override
+    public GuiWindow<C> getWindow() {
+        return window;
+    }
+
+    @Override
+    public GuiHandler<C> getGuiHandler() {
+        return guiHandler;
+    }
+}

--- a/nmsutil-v1_15_R1/src/main/java/me/wolfyscript/utilities/api/nms/v1_15_R1/inventory/GUIInventoryImpl.java
+++ b/nmsutil-v1_15_R1/src/main/java/me/wolfyscript/utilities/api/nms/v1_15_R1/inventory/GUIInventoryImpl.java
@@ -1,0 +1,30 @@
+package me.wolfyscript.utilities.api.nms.v1_15_R1.inventory;
+
+import me.wolfyscript.utilities.api.inventory.gui.GuiHandler;
+import me.wolfyscript.utilities.api.inventory.gui.GuiWindow;
+import me.wolfyscript.utilities.api.inventory.gui.cache.CustomCache;
+import me.wolfyscript.utilities.api.nms.inventory.GUIInventory;
+import net.minecraft.server.v1_15_R1.IInventory;
+import org.bukkit.craftbukkit.v1_15_R1.inventory.CraftInventory;
+
+public class GUIInventoryImpl<C extends CustomCache> extends CraftInventory implements GUIInventory<C> {
+
+    private final GuiWindow<C> window;
+    private final GuiHandler<C> guiHandler;
+
+    public GUIInventoryImpl(GuiHandler<C> guiHandler, GuiWindow<C> window, IInventory inventory) {
+        super(inventory);
+        this.guiHandler = guiHandler;
+        this.window = window;
+    }
+
+    @Override
+    public GuiWindow<C> getWindow() {
+        return window;
+    }
+
+    @Override
+    public GuiHandler<C> getGuiHandler() {
+        return guiHandler;
+    }
+}

--- a/nmsutil-v1_15_R1/src/main/java/me/wolfyscript/utilities/api/nms/v1_15_R1/inventory/util/GUICustomInventoryConverter.java
+++ b/nmsutil-v1_15_R1/src/main/java/me/wolfyscript/utilities/api/nms/v1_15_R1/inventory/util/GUICustomInventoryConverter.java
@@ -1,0 +1,33 @@
+package me.wolfyscript.utilities.api.nms.v1_15_R1.inventory.util;
+
+import me.wolfyscript.utilities.api.inventory.gui.GuiHandler;
+import me.wolfyscript.utilities.api.inventory.gui.GuiWindow;
+import me.wolfyscript.utilities.api.inventory.gui.cache.CustomCache;
+import me.wolfyscript.utilities.api.nms.inventory.GUIInventory;
+import me.wolfyscript.utilities.api.nms.v1_15_R1.inventory.GUIInventoryCustom;
+import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.inventory.InventoryHolder;
+
+public class GUICustomInventoryConverter implements GUIInventoryCreator.InventoryConverter {
+
+    public GUICustomInventoryConverter() {
+    }
+
+    @Override
+    public <C extends CustomCache> GUIInventory<C> createInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder holder, InventoryType type) {
+        return new GUIInventoryCustom<>(guiHandler, window, holder, type);
+    }
+
+    @Override
+    public <C extends CustomCache> GUIInventory<C> createInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder holder, InventoryType type, String title) {
+        return new GUIInventoryCustom<>(guiHandler, window, holder, type, title);
+    }
+
+    public <C extends CustomCache> GUIInventory<C> createInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder owner, int size) {
+        return new GUIInventoryCustom<>(guiHandler, window, owner, size);
+    }
+
+    public <C extends CustomCache> GUIInventory<C> createInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder owner, int size, String title) {
+        return new GUIInventoryCustom<>(guiHandler, window, owner, size, title);
+    }
+}

--- a/nmsutil-v1_15_R1/src/main/java/me/wolfyscript/utilities/api/nms/v1_15_R1/inventory/util/GUIInventoryCreator.java
+++ b/nmsutil-v1_15_R1/src/main/java/me/wolfyscript/utilities/api/nms/v1_15_R1/inventory/util/GUIInventoryCreator.java
@@ -1,0 +1,69 @@
+package me.wolfyscript.utilities.api.nms.v1_15_R1.inventory.util;
+
+import me.wolfyscript.utilities.api.inventory.gui.GuiHandler;
+import me.wolfyscript.utilities.api.inventory.gui.GuiWindow;
+import me.wolfyscript.utilities.api.inventory.gui.cache.CustomCache;
+import me.wolfyscript.utilities.api.nms.inventory.GUIInventory;
+import org.apache.commons.lang.Validate;
+import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.inventory.InventoryHolder;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class GUIInventoryCreator {
+
+    public static final GUIInventoryCreator INSTANCE = new GUIInventoryCreator();
+    private final GUICustomInventoryConverter DEFAULT_CONVERTER = new GUICustomInventoryConverter();
+    private final Map<InventoryType, InventoryConverter> converterMap = new HashMap<>();
+
+    private GUIInventoryCreator() {
+        this.converterMap.put(InventoryType.CHEST, this.DEFAULT_CONVERTER);
+        this.converterMap.put(InventoryType.DISPENSER, new GUITileInventoryConverter.Dispenser());
+        this.converterMap.put(InventoryType.DROPPER, new GUITileInventoryConverter.Dropper());
+        this.converterMap.put(InventoryType.FURNACE, new GUITileInventoryConverter.Furnace());
+        this.converterMap.put(InventoryType.WORKBENCH, this.DEFAULT_CONVERTER);
+        this.converterMap.put(InventoryType.ENCHANTING, this.DEFAULT_CONVERTER);
+        this.converterMap.put(InventoryType.BREWING, new GUITileInventoryConverter.BrewingStand());
+        this.converterMap.put(InventoryType.PLAYER, this.DEFAULT_CONVERTER);
+        this.converterMap.put(InventoryType.MERCHANT, this.DEFAULT_CONVERTER);
+        this.converterMap.put(InventoryType.ENDER_CHEST, this.DEFAULT_CONVERTER);
+        this.converterMap.put(InventoryType.ANVIL, this.DEFAULT_CONVERTER);
+        this.converterMap.put(InventoryType.BEACON, this.DEFAULT_CONVERTER);
+        this.converterMap.put(InventoryType.HOPPER, new GUITileInventoryConverter.Hopper());
+        this.converterMap.put(InventoryType.SHULKER_BOX, this.DEFAULT_CONVERTER);
+        this.converterMap.put(InventoryType.BARREL, this.DEFAULT_CONVERTER);
+        this.converterMap.put(InventoryType.BLAST_FURNACE, new GUITileInventoryConverter.BlastFurnace());
+        this.converterMap.put(InventoryType.LECTERN, new GUITileInventoryConverter.Lectern());
+        this.converterMap.put(InventoryType.SMOKER, new GUITileInventoryConverter.Smoker());
+        this.converterMap.put(InventoryType.LOOM, this.DEFAULT_CONVERTER);
+        this.converterMap.put(InventoryType.CARTOGRAPHY, this.DEFAULT_CONVERTER);
+        this.converterMap.put(InventoryType.GRINDSTONE, this.DEFAULT_CONVERTER);
+        this.converterMap.put(InventoryType.STONECUTTER, this.DEFAULT_CONVERTER);
+    }
+
+    public <C extends CustomCache> GUIInventory<C> createInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder holder, InventoryType type) {
+        Validate.isTrue(this.converterMap.containsKey(type), "Cannot create GUI inventory of type ", type);
+        return this.converterMap.get(type).createInventory(guiHandler, window, holder, type);
+    }
+
+    public <C extends CustomCache> GUIInventory<C> createInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder holder, InventoryType type, String title) {
+        Validate.isTrue(this.converterMap.containsKey(type), "Cannot create GUI inventory of type ", type);
+        return this.converterMap.get(type).createInventory(guiHandler, window, holder, type, title);
+    }
+
+    public <C extends CustomCache> GUIInventory<C> createInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder holder, int size) {
+        return this.DEFAULT_CONVERTER.createInventory(guiHandler, window, holder, size);
+    }
+
+    public <C extends CustomCache> GUIInventory<C> createInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder holder, int size, String title) {
+        return this.DEFAULT_CONVERTER.createInventory(guiHandler, window, holder, size, title);
+    }
+
+    public interface InventoryConverter {
+
+        <C extends CustomCache> GUIInventory<C> createInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder holder, InventoryType type);
+
+        <C extends CustomCache> GUIInventory<C> createInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder holder, InventoryType type, String title);
+    }
+}

--- a/nmsutil-v1_15_R1/src/main/java/me/wolfyscript/utilities/api/nms/v1_15_R1/inventory/util/GUITileInventoryConverter.java
+++ b/nmsutil-v1_15_R1/src/main/java/me/wolfyscript/utilities/api/nms/v1_15_R1/inventory/util/GUITileInventoryConverter.java
@@ -1,0 +1,126 @@
+package me.wolfyscript.utilities.api.nms.v1_15_R1.inventory.util;
+
+import me.wolfyscript.utilities.api.inventory.gui.GuiHandler;
+import me.wolfyscript.utilities.api.inventory.gui.GuiWindow;
+import me.wolfyscript.utilities.api.inventory.gui.cache.CustomCache;
+import me.wolfyscript.utilities.api.nms.inventory.GUIInventory;
+import me.wolfyscript.utilities.api.nms.v1_15_R1.inventory.GUIInventoryBrewer;
+import me.wolfyscript.utilities.api.nms.v1_15_R1.inventory.GUIInventoryFurnace;
+import me.wolfyscript.utilities.api.nms.v1_15_R1.inventory.GUIInventoryImpl;
+import net.minecraft.server.v1_15_R1.*;
+import org.bukkit.craftbukkit.v1_15_R1.util.CraftChatMessage;
+import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.inventory.InventoryHolder;
+
+public abstract class GUITileInventoryConverter implements GUIInventoryCreator.InventoryConverter {
+
+    public GUITileInventoryConverter() {
+    }
+
+    public abstract IInventory getTileEntity();
+
+    @Override
+    public <C extends CustomCache> GUIInventory<C> createInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder holder, InventoryType type) {
+        return this.getInventory(guiHandler, window, this.getTileEntity());
+    }
+
+    @Override
+    public <C extends CustomCache> GUIInventory<C> createInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder holder, InventoryType type, String title) {
+        IInventory te = this.getTileEntity();
+        if (te instanceof TileEntityLootable) {
+            ((TileEntityLootable) te).setCustomName(CraftChatMessage.fromStringOrNull(title));
+        }
+        return this.getInventory(guiHandler, window, te);
+    }
+
+    public <C extends CustomCache> GUIInventory<C> getInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, IInventory tileEntity) {
+        return new GUIInventoryImpl<>(guiHandler, window, tileEntity);
+    }
+
+    //---------------------------Sub-Classes------------------------------------
+
+    public static class BlastFurnace extends GUITileInventoryConverter {
+        @Override
+        public IInventory getTileEntity() {
+            return new TileEntityBlastFurnace();
+        }
+    }
+
+    public static class BrewingStand extends GUITileInventoryConverter {
+        @Override
+        public IInventory getTileEntity() {
+            return new TileEntityBrewingStand();
+        }
+
+        @Override
+        public <C extends CustomCache> GUIInventory<C> createInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder holder, InventoryType type, String title) {
+            IInventory tileEntity = this.getTileEntity();
+            if (tileEntity instanceof TileEntityBrewingStand) {
+                ((TileEntityBrewingStand) tileEntity).setCustomName(CraftChatMessage.fromStringOrNull(title));
+            }
+            return this.getInventory(guiHandler, window, tileEntity);
+        }
+
+        @Override
+        public <C extends CustomCache> GUIInventory<C> getInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, IInventory tileEntity) {
+            return new GUIInventoryBrewer<>(guiHandler, window, tileEntity);
+        }
+    }
+
+    public static class Dispenser extends GUITileInventoryConverter {
+        @Override
+        public IInventory getTileEntity() {
+            return new TileEntityDispenser();
+        }
+    }
+
+    public static class Dropper extends GUITileInventoryConverter {
+        @Override
+        public IInventory getTileEntity() {
+            return new TileEntityDropper();
+        }
+    }
+
+    public static class Furnace extends GUITileInventoryConverter {
+
+        @Override
+        public IInventory getTileEntity() {
+            TileEntityFurnace furnace = new TileEntityFurnaceFurnace();
+            furnace.setLocation(MinecraftServer.getServer().getWorldServer(DimensionManager.OVERWORLD), BlockPosition.ZERO);
+            return furnace;
+        }
+
+        @Override
+        public <C extends CustomCache> GUIInventory<C> createInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder holder, InventoryType type, String title) {
+            IInventory tileEntity = this.getTileEntity();
+            ((TileEntityFurnace) tileEntity).setCustomName(CraftChatMessage.fromStringOrNull(title));
+            return this.getInventory(guiHandler, window, tileEntity);
+        }
+
+        @Override
+        public <C extends CustomCache> GUIInventory<C> getInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, IInventory tileEntity) {
+            return new GUIInventoryFurnace<>(guiHandler, window, (TileEntityFurnace) tileEntity);
+        }
+    }
+
+    public static class Hopper extends GUITileInventoryConverter {
+        @Override
+        public IInventory getTileEntity() {
+            return new TileEntityHopper();
+        }
+    }
+
+    public static class Lectern extends GUITileInventoryConverter {
+        @Override
+        public IInventory getTileEntity() {
+            return (new TileEntityLectern()).inventory;
+        }
+    }
+
+    public static class Smoker extends GUITileInventoryConverter {
+        @Override
+        public IInventory getTileEntity() {
+            return new TileEntitySmoker();
+        }
+    }
+}

--- a/nmsutil-v1_16_R1/src/main/java/me/wolfyscript/utilities/api/nms/v1_16_R1/InventoryUtilImpl.java
+++ b/nmsutil-v1_16_R1/src/main/java/me/wolfyscript/utilities/api/nms/v1_16_R1/InventoryUtilImpl.java
@@ -17,21 +17,21 @@ public class InventoryUtilImpl extends InventoryUtil {
 
     @Override
     public <C extends CustomCache> GUIInventory<C> createGUIInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryType type) {
-        return GUIInventoryCreator.INSTANCE.createInventory(guiHandler, window, guiHandler, type);
+        return GUIInventoryCreator.INSTANCE.createInventory(guiHandler, window, null, type);
     }
 
     @Override
     public <C extends CustomCache> GUIInventory<C> createGUIInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryType type, String title) {
-        return GUIInventoryCreator.INSTANCE.createInventory(guiHandler, window, guiHandler, type, title);
+        return GUIInventoryCreator.INSTANCE.createInventory(guiHandler, window, null, type, title);
     }
 
     @Override
     public <C extends CustomCache> GUIInventory<C> createGUIInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, int size) {
-        return GUIInventoryCreator.INSTANCE.createInventory(guiHandler, window, guiHandler, size);
+        return GUIInventoryCreator.INSTANCE.createInventory(guiHandler, window, null, size);
     }
 
     @Override
     public <C extends CustomCache> GUIInventory<C> createGUIInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, int size, String title) {
-        return GUIInventoryCreator.INSTANCE.createInventory(guiHandler, window, guiHandler, size, title);
+        return GUIInventoryCreator.INSTANCE.createInventory(guiHandler, window, null, size, title);
     }
 }

--- a/nmsutil-v1_16_R1/src/main/java/me/wolfyscript/utilities/api/nms/v1_16_R1/InventoryUtilImpl.java
+++ b/nmsutil-v1_16_R1/src/main/java/me/wolfyscript/utilities/api/nms/v1_16_R1/InventoryUtilImpl.java
@@ -1,0 +1,37 @@
+package me.wolfyscript.utilities.api.nms.v1_16_R1;
+
+import me.wolfyscript.utilities.api.inventory.gui.GuiHandler;
+import me.wolfyscript.utilities.api.inventory.gui.GuiWindow;
+import me.wolfyscript.utilities.api.inventory.gui.cache.CustomCache;
+import me.wolfyscript.utilities.api.nms.InventoryUtil;
+import me.wolfyscript.utilities.api.nms.NMSUtil;
+import me.wolfyscript.utilities.api.nms.inventory.GUIInventory;
+import me.wolfyscript.utilities.api.nms.v1_16_R1.inventory.util.GUIInventoryCreator;
+import org.bukkit.event.inventory.InventoryType;
+
+public class InventoryUtilImpl extends InventoryUtil {
+
+    protected InventoryUtilImpl(NMSUtil nmsUtil) {
+        super(nmsUtil);
+    }
+
+    @Override
+    public <C extends CustomCache> GUIInventory<C> createGUIInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryType type) {
+        return GUIInventoryCreator.INSTANCE.createInventory(guiHandler, window, guiHandler, type);
+    }
+
+    @Override
+    public <C extends CustomCache> GUIInventory<C> createGUIInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryType type, String title) {
+        return GUIInventoryCreator.INSTANCE.createInventory(guiHandler, window, guiHandler, type, title);
+    }
+
+    @Override
+    public <C extends CustomCache> GUIInventory<C> createGUIInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, int size) {
+        return GUIInventoryCreator.INSTANCE.createInventory(guiHandler, window, guiHandler, size);
+    }
+
+    @Override
+    public <C extends CustomCache> GUIInventory<C> createGUIInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, int size, String title) {
+        return GUIInventoryCreator.INSTANCE.createInventory(guiHandler, window, guiHandler, size, title);
+    }
+}

--- a/nmsutil-v1_16_R1/src/main/java/me/wolfyscript/utilities/api/nms/v1_16_R1/NMSEntry.java
+++ b/nmsutil-v1_16_R1/src/main/java/me/wolfyscript/utilities/api/nms/v1_16_R1/NMSEntry.java
@@ -11,6 +11,7 @@ public class NMSEntry extends NMSUtil {
 
     private final BlockUtil blockUtil;
     private final ItemUtil itemUtil;
+    private final InventoryUtil inventoryUtil;
 
     /**
      * The class that implements this NMSUtil needs to have a constructor with just the {@link Plugin} parameter.
@@ -21,6 +22,7 @@ public class NMSEntry extends NMSUtil {
         super(wolfyUtilities);
         this.blockUtil = new BlockUtilImpl(this);
         this.itemUtil = new ItemUtilImpl(this);
+        this.inventoryUtil = new InventoryUtilImpl(this);
     }
 
     @Override
@@ -35,6 +37,6 @@ public class NMSEntry extends NMSUtil {
 
     @Override
     public InventoryUtil getInventoryUtil() {
-        return null;
+        return inventoryUtil;
     }
 }

--- a/nmsutil-v1_16_R1/src/main/java/me/wolfyscript/utilities/api/nms/v1_16_R1/NMSEntry.java
+++ b/nmsutil-v1_16_R1/src/main/java/me/wolfyscript/utilities/api/nms/v1_16_R1/NMSEntry.java
@@ -2,6 +2,7 @@ package me.wolfyscript.utilities.api.nms.v1_16_R1;
 
 import me.wolfyscript.utilities.api.WolfyUtilities;
 import me.wolfyscript.utilities.api.nms.BlockUtil;
+import me.wolfyscript.utilities.api.nms.InventoryUtil;
 import me.wolfyscript.utilities.api.nms.ItemUtil;
 import me.wolfyscript.utilities.api.nms.NMSUtil;
 import org.bukkit.plugin.Plugin;
@@ -32,5 +33,8 @@ public class NMSEntry extends NMSUtil {
         return itemUtil;
     }
 
-
+    @Override
+    public InventoryUtil getInventoryUtil() {
+        return null;
+    }
 }

--- a/nmsutil-v1_16_R1/src/main/java/me/wolfyscript/utilities/api/nms/v1_16_R1/inventory/GUIInventoryBrewer.java
+++ b/nmsutil-v1_16_R1/src/main/java/me/wolfyscript/utilities/api/nms/v1_16_R1/inventory/GUIInventoryBrewer.java
@@ -1,0 +1,30 @@
+package me.wolfyscript.utilities.api.nms.v1_16_R1.inventory;
+
+import me.wolfyscript.utilities.api.inventory.gui.GuiHandler;
+import me.wolfyscript.utilities.api.inventory.gui.GuiWindow;
+import me.wolfyscript.utilities.api.inventory.gui.cache.CustomCache;
+import me.wolfyscript.utilities.api.nms.inventory.GUIInventory;
+import net.minecraft.server.v1_16_R1.IInventory;
+import org.bukkit.craftbukkit.v1_16_R1.inventory.CraftInventoryBrewer;
+
+public class GUIInventoryBrewer<C extends CustomCache> extends CraftInventoryBrewer implements GUIInventory<C> {
+
+    private final GuiWindow<C> window;
+    private final GuiHandler<C> guiHandler;
+
+    public GUIInventoryBrewer(GuiHandler<C> guiHandler, GuiWindow<C> window, IInventory inventory) {
+        super(inventory);
+        this.guiHandler = guiHandler;
+        this.window = window;
+    }
+
+    @Override
+    public GuiWindow<C> getWindow() {
+        return window;
+    }
+
+    @Override
+    public GuiHandler<C> getGuiHandler() {
+        return guiHandler;
+    }
+}

--- a/nmsutil-v1_16_R1/src/main/java/me/wolfyscript/utilities/api/nms/v1_16_R1/inventory/GUIInventoryCustom.java
+++ b/nmsutil-v1_16_R1/src/main/java/me/wolfyscript/utilities/api/nms/v1_16_R1/inventory/GUIInventoryCustom.java
@@ -1,0 +1,49 @@
+package me.wolfyscript.utilities.api.nms.v1_16_R1.inventory;
+
+import me.wolfyscript.utilities.api.inventory.gui.GuiHandler;
+import me.wolfyscript.utilities.api.inventory.gui.GuiWindow;
+import me.wolfyscript.utilities.api.inventory.gui.cache.CustomCache;
+import me.wolfyscript.utilities.api.nms.inventory.GUIInventory;
+import org.bukkit.craftbukkit.v1_16_R1.inventory.CraftInventoryCustom;
+import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.inventory.InventoryHolder;
+
+public class GUIInventoryCustom<C extends CustomCache> extends CraftInventoryCustom implements GUIInventory<C> {
+
+    private final GuiWindow<C> window;
+    private final GuiHandler<C> guiHandler;
+
+    public GUIInventoryCustom(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder owner, InventoryType type) {
+        super(owner, type);
+        this.guiHandler = guiHandler;
+        this.window = window;
+    }
+
+    public GUIInventoryCustom(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder owner, InventoryType type, String title) {
+        super(owner, type, title);
+        this.guiHandler = guiHandler;
+        this.window = window;
+    }
+
+    public GUIInventoryCustom(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder owner, int size) {
+        super(owner, size);
+        this.guiHandler = guiHandler;
+        this.window = window;
+    }
+
+    public GUIInventoryCustom(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder owner, int size, String title) {
+        super(owner, size, title);
+        this.guiHandler = guiHandler;
+        this.window = window;
+    }
+
+    @Override
+    public GuiWindow<C> getWindow() {
+        return this.window;
+    }
+
+    @Override
+    public GuiHandler<C> getGuiHandler() {
+        return guiHandler;
+    }
+}

--- a/nmsutil-v1_16_R1/src/main/java/me/wolfyscript/utilities/api/nms/v1_16_R1/inventory/GUIInventoryFurnace.java
+++ b/nmsutil-v1_16_R1/src/main/java/me/wolfyscript/utilities/api/nms/v1_16_R1/inventory/GUIInventoryFurnace.java
@@ -1,0 +1,31 @@
+package me.wolfyscript.utilities.api.nms.v1_16_R1.inventory;
+
+import me.wolfyscript.utilities.api.inventory.gui.GuiHandler;
+import me.wolfyscript.utilities.api.inventory.gui.GuiWindow;
+import me.wolfyscript.utilities.api.inventory.gui.cache.CustomCache;
+import me.wolfyscript.utilities.api.nms.inventory.GUIInventory;
+import net.minecraft.server.v1_16_R1.TileEntityFurnace;
+import org.bukkit.craftbukkit.v1_16_R1.inventory.CraftInventoryFurnace;
+
+
+public class GUIInventoryFurnace<C extends CustomCache> extends CraftInventoryFurnace implements GUIInventory<C> {
+
+    private final GuiWindow<C> window;
+    private final GuiHandler<C> guiHandler;
+
+    public GUIInventoryFurnace(GuiHandler<C> guiHandler, GuiWindow<C> window, TileEntityFurnace inventory) {
+        super(inventory);
+        this.guiHandler = guiHandler;
+        this.window = window;
+    }
+
+    @Override
+    public GuiWindow<C> getWindow() {
+        return window;
+    }
+
+    @Override
+    public GuiHandler<C> getGuiHandler() {
+        return guiHandler;
+    }
+}

--- a/nmsutil-v1_16_R1/src/main/java/me/wolfyscript/utilities/api/nms/v1_16_R1/inventory/GUIInventoryImpl.java
+++ b/nmsutil-v1_16_R1/src/main/java/me/wolfyscript/utilities/api/nms/v1_16_R1/inventory/GUIInventoryImpl.java
@@ -1,0 +1,30 @@
+package me.wolfyscript.utilities.api.nms.v1_16_R1.inventory;
+
+import me.wolfyscript.utilities.api.inventory.gui.GuiHandler;
+import me.wolfyscript.utilities.api.inventory.gui.GuiWindow;
+import me.wolfyscript.utilities.api.inventory.gui.cache.CustomCache;
+import me.wolfyscript.utilities.api.nms.inventory.GUIInventory;
+import net.minecraft.server.v1_16_R1.IInventory;
+import org.bukkit.craftbukkit.v1_16_R1.inventory.CraftInventory;
+
+public class GUIInventoryImpl<C extends CustomCache> extends CraftInventory implements GUIInventory<C> {
+
+    private final GuiWindow<C> window;
+    private final GuiHandler<C> guiHandler;
+
+    public GUIInventoryImpl(GuiHandler<C> guiHandler, GuiWindow<C> window, IInventory inventory) {
+        super(inventory);
+        this.guiHandler = guiHandler;
+        this.window = window;
+    }
+
+    @Override
+    public GuiWindow<C> getWindow() {
+        return window;
+    }
+
+    @Override
+    public GuiHandler<C> getGuiHandler() {
+        return guiHandler;
+    }
+}

--- a/nmsutil-v1_16_R1/src/main/java/me/wolfyscript/utilities/api/nms/v1_16_R1/inventory/util/GUICustomInventoryConverter.java
+++ b/nmsutil-v1_16_R1/src/main/java/me/wolfyscript/utilities/api/nms/v1_16_R1/inventory/util/GUICustomInventoryConverter.java
@@ -1,0 +1,33 @@
+package me.wolfyscript.utilities.api.nms.v1_16_R1.inventory.util;
+
+import me.wolfyscript.utilities.api.inventory.gui.GuiHandler;
+import me.wolfyscript.utilities.api.inventory.gui.GuiWindow;
+import me.wolfyscript.utilities.api.inventory.gui.cache.CustomCache;
+import me.wolfyscript.utilities.api.nms.inventory.GUIInventory;
+import me.wolfyscript.utilities.api.nms.v1_16_R1.inventory.GUIInventoryCustom;
+import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.inventory.InventoryHolder;
+
+public class GUICustomInventoryConverter implements GUIInventoryCreator.InventoryConverter {
+
+    public GUICustomInventoryConverter() {
+    }
+
+    @Override
+    public <C extends CustomCache> GUIInventory<C> createInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder holder, InventoryType type) {
+        return new GUIInventoryCustom<>(guiHandler, window, holder, type);
+    }
+
+    @Override
+    public <C extends CustomCache> GUIInventory<C> createInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder holder, InventoryType type, String title) {
+        return new GUIInventoryCustom<>(guiHandler, window, holder, type, title);
+    }
+
+    public <C extends CustomCache> GUIInventory<C> createInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder owner, int size) {
+        return new GUIInventoryCustom<>(guiHandler, window, owner, size);
+    }
+
+    public <C extends CustomCache> GUIInventory<C> createInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder owner, int size, String title) {
+        return new GUIInventoryCustom<>(guiHandler, window, owner, size, title);
+    }
+}

--- a/nmsutil-v1_16_R1/src/main/java/me/wolfyscript/utilities/api/nms/v1_16_R1/inventory/util/GUIInventoryCreator.java
+++ b/nmsutil-v1_16_R1/src/main/java/me/wolfyscript/utilities/api/nms/v1_16_R1/inventory/util/GUIInventoryCreator.java
@@ -1,0 +1,70 @@
+package me.wolfyscript.utilities.api.nms.v1_16_R1.inventory.util;
+
+import me.wolfyscript.utilities.api.inventory.gui.GuiHandler;
+import me.wolfyscript.utilities.api.inventory.gui.GuiWindow;
+import me.wolfyscript.utilities.api.inventory.gui.cache.CustomCache;
+import me.wolfyscript.utilities.api.nms.inventory.GUIInventory;
+import org.apache.commons.lang.Validate;
+import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.inventory.InventoryHolder;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class GUIInventoryCreator {
+
+    public static final GUIInventoryCreator INSTANCE = new GUIInventoryCreator();
+    private final GUICustomInventoryConverter DEFAULT_CONVERTER = new GUICustomInventoryConverter();
+    private final Map<InventoryType, InventoryConverter> converterMap = new HashMap<>();
+
+    private GUIInventoryCreator() {
+        this.converterMap.put(InventoryType.CHEST, this.DEFAULT_CONVERTER);
+        this.converterMap.put(InventoryType.DISPENSER, new GUITileInventoryConverter.Dispenser());
+        this.converterMap.put(InventoryType.DROPPER, new GUITileInventoryConverter.Dropper());
+        this.converterMap.put(InventoryType.FURNACE, new GUITileInventoryConverter.Furnace());
+        this.converterMap.put(InventoryType.WORKBENCH, this.DEFAULT_CONVERTER);
+        this.converterMap.put(InventoryType.ENCHANTING, this.DEFAULT_CONVERTER);
+        this.converterMap.put(InventoryType.BREWING, new GUITileInventoryConverter.BrewingStand());
+        this.converterMap.put(InventoryType.PLAYER, this.DEFAULT_CONVERTER);
+        this.converterMap.put(InventoryType.MERCHANT, this.DEFAULT_CONVERTER);
+        this.converterMap.put(InventoryType.ENDER_CHEST, this.DEFAULT_CONVERTER);
+        this.converterMap.put(InventoryType.ANVIL, this.DEFAULT_CONVERTER);
+        this.converterMap.put(InventoryType.SMITHING, this.DEFAULT_CONVERTER);
+        this.converterMap.put(InventoryType.BEACON, this.DEFAULT_CONVERTER);
+        this.converterMap.put(InventoryType.HOPPER, new GUITileInventoryConverter.Hopper());
+        this.converterMap.put(InventoryType.SHULKER_BOX, this.DEFAULT_CONVERTER);
+        this.converterMap.put(InventoryType.BARREL, this.DEFAULT_CONVERTER);
+        this.converterMap.put(InventoryType.BLAST_FURNACE, new GUITileInventoryConverter.BlastFurnace());
+        this.converterMap.put(InventoryType.LECTERN, new GUITileInventoryConverter.Lectern());
+        this.converterMap.put(InventoryType.SMOKER, new GUITileInventoryConverter.Smoker());
+        this.converterMap.put(InventoryType.LOOM, this.DEFAULT_CONVERTER);
+        this.converterMap.put(InventoryType.CARTOGRAPHY, this.DEFAULT_CONVERTER);
+        this.converterMap.put(InventoryType.GRINDSTONE, this.DEFAULT_CONVERTER);
+        this.converterMap.put(InventoryType.STONECUTTER, this.DEFAULT_CONVERTER);
+    }
+
+    public <C extends CustomCache> GUIInventory<C> createInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder holder, InventoryType type) {
+        Validate.isTrue(this.converterMap.containsKey(type), "Cannot create GUI inventory of type ", type);
+        return this.converterMap.get(type).createInventory(guiHandler, window, holder, type);
+    }
+
+    public <C extends CustomCache> GUIInventory<C> createInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder holder, InventoryType type, String title) {
+        Validate.isTrue(this.converterMap.containsKey(type), "Cannot create GUI inventory of type ", type);
+        return this.converterMap.get(type).createInventory(guiHandler, window, holder, type, title);
+    }
+
+    public <C extends CustomCache> GUIInventory<C> createInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder holder, int size) {
+        return this.DEFAULT_CONVERTER.createInventory(guiHandler, window, holder, size);
+    }
+
+    public <C extends CustomCache> GUIInventory<C> createInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder holder, int size, String title) {
+        return this.DEFAULT_CONVERTER.createInventory(guiHandler, window, holder, size, title);
+    }
+
+    public interface InventoryConverter {
+
+        <C extends CustomCache> GUIInventory<C> createInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder holder, InventoryType type);
+
+        <C extends CustomCache> GUIInventory<C> createInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder holder, InventoryType type, String title);
+    }
+}

--- a/nmsutil-v1_16_R1/src/main/java/me/wolfyscript/utilities/api/nms/v1_16_R1/inventory/util/GUITileInventoryConverter.java
+++ b/nmsutil-v1_16_R1/src/main/java/me/wolfyscript/utilities/api/nms/v1_16_R1/inventory/util/GUITileInventoryConverter.java
@@ -1,0 +1,126 @@
+package me.wolfyscript.utilities.api.nms.v1_16_R1.inventory.util;
+
+import me.wolfyscript.utilities.api.inventory.gui.GuiHandler;
+import me.wolfyscript.utilities.api.inventory.gui.GuiWindow;
+import me.wolfyscript.utilities.api.inventory.gui.cache.CustomCache;
+import me.wolfyscript.utilities.api.nms.inventory.GUIInventory;
+import me.wolfyscript.utilities.api.nms.v1_16_R1.inventory.GUIInventoryBrewer;
+import me.wolfyscript.utilities.api.nms.v1_16_R1.inventory.GUIInventoryFurnace;
+import me.wolfyscript.utilities.api.nms.v1_16_R1.inventory.GUIInventoryImpl;
+import net.minecraft.server.v1_16_R1.*;
+import org.bukkit.craftbukkit.v1_16_R1.util.CraftChatMessage;
+import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.inventory.InventoryHolder;
+
+public abstract class GUITileInventoryConverter implements GUIInventoryCreator.InventoryConverter {
+
+    public GUITileInventoryConverter() {
+    }
+
+    public abstract IInventory getTileEntity();
+
+    @Override
+    public <C extends CustomCache> GUIInventory<C> createInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder holder, InventoryType type) {
+        return this.getInventory(guiHandler, window, this.getTileEntity());
+    }
+
+    @Override
+    public <C extends CustomCache> GUIInventory<C> createInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder holder, InventoryType type, String title) {
+        IInventory te = this.getTileEntity();
+        if (te instanceof TileEntityLootable) {
+            ((TileEntityLootable) te).setCustomName(CraftChatMessage.fromStringOrNull(title));
+        }
+        return this.getInventory(guiHandler, window, te);
+    }
+
+    public <C extends CustomCache> GUIInventory<C> getInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, IInventory tileEntity) {
+        return new GUIInventoryImpl<>(guiHandler, window, tileEntity);
+    }
+
+    //---------------------------Sub-Classes------------------------------------
+
+    public static class BlastFurnace extends GUITileInventoryConverter {
+        @Override
+        public IInventory getTileEntity() {
+            return new TileEntityBlastFurnace();
+        }
+    }
+
+    public static class BrewingStand extends GUITileInventoryConverter {
+        @Override
+        public IInventory getTileEntity() {
+            return new TileEntityBrewingStand();
+        }
+
+        @Override
+        public <C extends CustomCache> GUIInventory<C> createInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder holder, InventoryType type, String title) {
+            IInventory tileEntity = this.getTileEntity();
+            if (tileEntity instanceof TileEntityBrewingStand) {
+                ((TileEntityBrewingStand) tileEntity).setCustomName(CraftChatMessage.fromStringOrNull(title));
+            }
+            return this.getInventory(guiHandler, window, tileEntity);
+        }
+
+        @Override
+        public <C extends CustomCache> GUIInventory<C> getInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, IInventory tileEntity) {
+            return new GUIInventoryBrewer<>(guiHandler, window, tileEntity);
+        }
+    }
+
+    public static class Dispenser extends GUITileInventoryConverter {
+        @Override
+        public IInventory getTileEntity() {
+            return new TileEntityDispenser();
+        }
+    }
+
+    public static class Dropper extends GUITileInventoryConverter {
+        @Override
+        public IInventory getTileEntity() {
+            return new TileEntityDropper();
+        }
+    }
+
+    public static class Furnace extends GUITileInventoryConverter {
+
+        @Override
+        public IInventory getTileEntity() {
+            TileEntityFurnace furnace = new TileEntityFurnaceFurnace();
+            furnace.setLocation(MinecraftServer.getServer().getWorldServer(World.OVERWORLD), BlockPosition.ZERO);
+            return furnace;
+        }
+
+        @Override
+        public <C extends CustomCache> GUIInventory<C> createInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder holder, InventoryType type, String title) {
+            IInventory tileEntity = this.getTileEntity();
+            ((TileEntityFurnace) tileEntity).setCustomName(CraftChatMessage.fromStringOrNull(title));
+            return this.getInventory(guiHandler, window, tileEntity);
+        }
+
+        @Override
+        public <C extends CustomCache> GUIInventory<C> getInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, IInventory tileEntity) {
+            return new GUIInventoryFurnace<>(guiHandler, window, (TileEntityFurnace) tileEntity);
+        }
+    }
+
+    public static class Hopper extends GUITileInventoryConverter {
+        @Override
+        public IInventory getTileEntity() {
+            return new TileEntityHopper();
+        }
+    }
+
+    public static class Lectern extends GUITileInventoryConverter {
+        @Override
+        public IInventory getTileEntity() {
+            return (new TileEntityLectern()).inventory;
+        }
+    }
+
+    public static class Smoker extends GUITileInventoryConverter {
+        @Override
+        public IInventory getTileEntity() {
+            return new TileEntitySmoker();
+        }
+    }
+}

--- a/nmsutil-v1_16_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_16_R2/InventoryUtilImpl.java
+++ b/nmsutil-v1_16_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_16_R2/InventoryUtilImpl.java
@@ -17,21 +17,21 @@ public class InventoryUtilImpl extends InventoryUtil {
 
     @Override
     public <C extends CustomCache> GUIInventory<C> createGUIInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryType type) {
-        return GUIInventoryCreator.INSTANCE.createInventory(guiHandler, window, guiHandler, type);
+        return GUIInventoryCreator.INSTANCE.createInventory(guiHandler, window, null, type);
     }
 
     @Override
     public <C extends CustomCache> GUIInventory<C> createGUIInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryType type, String title) {
-        return GUIInventoryCreator.INSTANCE.createInventory(guiHandler, window, guiHandler, type, title);
+        return GUIInventoryCreator.INSTANCE.createInventory(guiHandler, window, null, type, title);
     }
 
     @Override
     public <C extends CustomCache> GUIInventory<C> createGUIInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, int size) {
-        return GUIInventoryCreator.INSTANCE.createInventory(guiHandler, window, guiHandler, size);
+        return GUIInventoryCreator.INSTANCE.createInventory(guiHandler, window, null, size);
     }
 
     @Override
     public <C extends CustomCache> GUIInventory<C> createGUIInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, int size, String title) {
-        return GUIInventoryCreator.INSTANCE.createInventory(guiHandler, window, guiHandler, size, title);
+        return GUIInventoryCreator.INSTANCE.createInventory(guiHandler, window, null, size, title);
     }
 }

--- a/nmsutil-v1_16_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_16_R2/InventoryUtilImpl.java
+++ b/nmsutil-v1_16_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_16_R2/InventoryUtilImpl.java
@@ -1,0 +1,37 @@
+package me.wolfyscript.utilities.api.nms.v1_16_R2;
+
+import me.wolfyscript.utilities.api.inventory.gui.GuiHandler;
+import me.wolfyscript.utilities.api.inventory.gui.GuiWindow;
+import me.wolfyscript.utilities.api.inventory.gui.cache.CustomCache;
+import me.wolfyscript.utilities.api.nms.InventoryUtil;
+import me.wolfyscript.utilities.api.nms.NMSUtil;
+import me.wolfyscript.utilities.api.nms.inventory.GUIInventory;
+import me.wolfyscript.utilities.api.nms.v1_16_R2.inventory.util.GUIInventoryCreator;
+import org.bukkit.event.inventory.InventoryType;
+
+public class InventoryUtilImpl extends InventoryUtil {
+
+    protected InventoryUtilImpl(NMSUtil nmsUtil) {
+        super(nmsUtil);
+    }
+
+    @Override
+    public <C extends CustomCache> GUIInventory<C> createGUIInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryType type) {
+        return GUIInventoryCreator.INSTANCE.createInventory(guiHandler, window, guiHandler, type);
+    }
+
+    @Override
+    public <C extends CustomCache> GUIInventory<C> createGUIInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryType type, String title) {
+        return GUIInventoryCreator.INSTANCE.createInventory(guiHandler, window, guiHandler, type, title);
+    }
+
+    @Override
+    public <C extends CustomCache> GUIInventory<C> createGUIInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, int size) {
+        return GUIInventoryCreator.INSTANCE.createInventory(guiHandler, window, guiHandler, size);
+    }
+
+    @Override
+    public <C extends CustomCache> GUIInventory<C> createGUIInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, int size, String title) {
+        return GUIInventoryCreator.INSTANCE.createInventory(guiHandler, window, guiHandler, size, title);
+    }
+}

--- a/nmsutil-v1_16_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_16_R2/ItemUtilImpl.java
+++ b/nmsutil-v1_16_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_16_R2/ItemUtilImpl.java
@@ -16,7 +16,6 @@ import java.util.Base64;
 
 public class ItemUtilImpl extends ItemUtil {
 
-
     protected ItemUtilImpl(NMSUtil nmsUtil) {
         super(nmsUtil);
     }

--- a/nmsutil-v1_16_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_16_R2/NMSEntry.java
+++ b/nmsutil-v1_16_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_16_R2/NMSEntry.java
@@ -11,6 +11,7 @@ public class NMSEntry extends NMSUtil {
 
     private final BlockUtil blockUtil;
     private final ItemUtil itemUtil;
+    private final InventoryUtil inventoryUtil;
 
     /**
      * The class that implements this NMSUtil needs to have a constructor with just the {@link Plugin} parameter.
@@ -21,6 +22,7 @@ public class NMSEntry extends NMSUtil {
         super(wolfyUtilities);
         this.blockUtil = new BlockUtilImpl(this);
         this.itemUtil = new ItemUtilImpl(this);
+        this.inventoryUtil = new InventoryUtilImpl(this);
     }
 
     @Override
@@ -35,6 +37,6 @@ public class NMSEntry extends NMSUtil {
 
     @Override
     public InventoryUtil getInventoryUtil() {
-        return null;
+        return inventoryUtil;
     }
 }

--- a/nmsutil-v1_16_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_16_R2/NMSEntry.java
+++ b/nmsutil-v1_16_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_16_R2/NMSEntry.java
@@ -2,6 +2,7 @@ package me.wolfyscript.utilities.api.nms.v1_16_R2;
 
 import me.wolfyscript.utilities.api.WolfyUtilities;
 import me.wolfyscript.utilities.api.nms.BlockUtil;
+import me.wolfyscript.utilities.api.nms.InventoryUtil;
 import me.wolfyscript.utilities.api.nms.ItemUtil;
 import me.wolfyscript.utilities.api.nms.NMSUtil;
 import org.bukkit.plugin.Plugin;
@@ -32,5 +33,8 @@ public class NMSEntry extends NMSUtil {
         return itemUtil;
     }
 
-
+    @Override
+    public InventoryUtil getInventoryUtil() {
+        return null;
+    }
 }

--- a/nmsutil-v1_16_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_16_R2/inventory/GUIInventoryBrewer.java
+++ b/nmsutil-v1_16_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_16_R2/inventory/GUIInventoryBrewer.java
@@ -1,0 +1,30 @@
+package me.wolfyscript.utilities.api.nms.v1_16_R2.inventory;
+
+import me.wolfyscript.utilities.api.inventory.gui.GuiHandler;
+import me.wolfyscript.utilities.api.inventory.gui.GuiWindow;
+import me.wolfyscript.utilities.api.inventory.gui.cache.CustomCache;
+import me.wolfyscript.utilities.api.nms.inventory.GUIInventory;
+import net.minecraft.server.v1_16_R2.IInventory;
+import org.bukkit.craftbukkit.v1_16_R2.inventory.CraftInventoryBrewer;
+
+public class GUIInventoryBrewer<C extends CustomCache> extends CraftInventoryBrewer implements GUIInventory<C> {
+
+    private final GuiWindow<C> window;
+    private final GuiHandler<C> guiHandler;
+
+    public GUIInventoryBrewer(GuiHandler<C> guiHandler, GuiWindow<C> window, IInventory inventory) {
+        super(inventory);
+        this.guiHandler = guiHandler;
+        this.window = window;
+    }
+
+    @Override
+    public GuiWindow<C> getWindow() {
+        return window;
+    }
+
+    @Override
+    public GuiHandler<C> getGuiHandler() {
+        return guiHandler;
+    }
+}

--- a/nmsutil-v1_16_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_16_R2/inventory/GUIInventoryCustom.java
+++ b/nmsutil-v1_16_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_16_R2/inventory/GUIInventoryCustom.java
@@ -1,0 +1,49 @@
+package me.wolfyscript.utilities.api.nms.v1_16_R2.inventory;
+
+import me.wolfyscript.utilities.api.inventory.gui.GuiHandler;
+import me.wolfyscript.utilities.api.inventory.gui.GuiWindow;
+import me.wolfyscript.utilities.api.inventory.gui.cache.CustomCache;
+import me.wolfyscript.utilities.api.nms.inventory.GUIInventory;
+import org.bukkit.craftbukkit.v1_16_R2.inventory.CraftInventoryCustom;
+import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.inventory.InventoryHolder;
+
+public class GUIInventoryCustom<C extends CustomCache> extends CraftInventoryCustom implements GUIInventory<C> {
+
+    private final GuiWindow<C> window;
+    private final GuiHandler<C> guiHandler;
+
+    public GUIInventoryCustom(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder owner, InventoryType type) {
+        super(owner, type);
+        this.guiHandler = guiHandler;
+        this.window = window;
+    }
+
+    public GUIInventoryCustom(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder owner, InventoryType type, String title) {
+        super(owner, type, title);
+        this.guiHandler = guiHandler;
+        this.window = window;
+    }
+
+    public GUIInventoryCustom(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder owner, int size) {
+        super(owner, size);
+        this.guiHandler = guiHandler;
+        this.window = window;
+    }
+
+    public GUIInventoryCustom(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder owner, int size, String title) {
+        super(owner, size, title);
+        this.guiHandler = guiHandler;
+        this.window = window;
+    }
+
+    @Override
+    public GuiWindow<C> getWindow() {
+        return this.window;
+    }
+
+    @Override
+    public GuiHandler<C> getGuiHandler() {
+        return guiHandler;
+    }
+}

--- a/nmsutil-v1_16_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_16_R2/inventory/GUIInventoryFurnace.java
+++ b/nmsutil-v1_16_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_16_R2/inventory/GUIInventoryFurnace.java
@@ -1,0 +1,31 @@
+package me.wolfyscript.utilities.api.nms.v1_16_R2.inventory;
+
+import me.wolfyscript.utilities.api.inventory.gui.GuiHandler;
+import me.wolfyscript.utilities.api.inventory.gui.GuiWindow;
+import me.wolfyscript.utilities.api.inventory.gui.cache.CustomCache;
+import me.wolfyscript.utilities.api.nms.inventory.GUIInventory;
+import net.minecraft.server.v1_16_R2.TileEntityFurnace;
+import org.bukkit.craftbukkit.v1_16_R2.inventory.CraftInventoryFurnace;
+
+
+public class GUIInventoryFurnace<C extends CustomCache> extends CraftInventoryFurnace implements GUIInventory<C> {
+
+    private final GuiWindow<C> window;
+    private final GuiHandler<C> guiHandler;
+
+    public GUIInventoryFurnace(GuiHandler<C> guiHandler, GuiWindow<C> window, TileEntityFurnace inventory) {
+        super(inventory);
+        this.guiHandler = guiHandler;
+        this.window = window;
+    }
+
+    @Override
+    public GuiWindow<C> getWindow() {
+        return window;
+    }
+
+    @Override
+    public GuiHandler<C> getGuiHandler() {
+        return guiHandler;
+    }
+}

--- a/nmsutil-v1_16_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_16_R2/inventory/GUIInventoryImpl.java
+++ b/nmsutil-v1_16_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_16_R2/inventory/GUIInventoryImpl.java
@@ -1,0 +1,30 @@
+package me.wolfyscript.utilities.api.nms.v1_16_R2.inventory;
+
+import me.wolfyscript.utilities.api.inventory.gui.GuiHandler;
+import me.wolfyscript.utilities.api.inventory.gui.GuiWindow;
+import me.wolfyscript.utilities.api.inventory.gui.cache.CustomCache;
+import me.wolfyscript.utilities.api.nms.inventory.GUIInventory;
+import net.minecraft.server.v1_16_R2.IInventory;
+import org.bukkit.craftbukkit.v1_16_R2.inventory.CraftInventory;
+
+public class GUIInventoryImpl<C extends CustomCache> extends CraftInventory implements GUIInventory<C> {
+
+    private final GuiWindow<C> window;
+    private final GuiHandler<C> guiHandler;
+
+    public GUIInventoryImpl(GuiHandler<C> guiHandler, GuiWindow<C> window, IInventory inventory) {
+        super(inventory);
+        this.guiHandler = guiHandler;
+        this.window = window;
+    }
+
+    @Override
+    public GuiWindow<C> getWindow() {
+        return window;
+    }
+
+    @Override
+    public GuiHandler<C> getGuiHandler() {
+        return guiHandler;
+    }
+}

--- a/nmsutil-v1_16_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_16_R2/inventory/util/GUICustomInventoryConverter.java
+++ b/nmsutil-v1_16_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_16_R2/inventory/util/GUICustomInventoryConverter.java
@@ -1,0 +1,33 @@
+package me.wolfyscript.utilities.api.nms.v1_16_R2.inventory.util;
+
+import me.wolfyscript.utilities.api.inventory.gui.GuiHandler;
+import me.wolfyscript.utilities.api.inventory.gui.GuiWindow;
+import me.wolfyscript.utilities.api.inventory.gui.cache.CustomCache;
+import me.wolfyscript.utilities.api.nms.inventory.GUIInventory;
+import me.wolfyscript.utilities.api.nms.v1_16_R2.inventory.GUIInventoryCustom;
+import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.inventory.InventoryHolder;
+
+public class GUICustomInventoryConverter implements GUIInventoryCreator.InventoryConverter {
+
+    public GUICustomInventoryConverter() {
+    }
+
+    @Override
+    public <C extends CustomCache> GUIInventory<C> createInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder holder, InventoryType type) {
+        return new GUIInventoryCustom<>(guiHandler, window, holder, type);
+    }
+
+    @Override
+    public <C extends CustomCache> GUIInventory<C> createInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder holder, InventoryType type, String title) {
+        return new GUIInventoryCustom<>(guiHandler, window, holder, type, title);
+    }
+
+    public <C extends CustomCache> GUIInventory<C> createInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder owner, int size) {
+        return new GUIInventoryCustom<>(guiHandler, window, owner, size);
+    }
+
+    public <C extends CustomCache> GUIInventory<C> createInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder owner, int size, String title) {
+        return new GUIInventoryCustom<>(guiHandler, window, owner, size, title);
+    }
+}

--- a/nmsutil-v1_16_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_16_R2/inventory/util/GUIInventoryCreator.java
+++ b/nmsutil-v1_16_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_16_R2/inventory/util/GUIInventoryCreator.java
@@ -1,0 +1,70 @@
+package me.wolfyscript.utilities.api.nms.v1_16_R2.inventory.util;
+
+import me.wolfyscript.utilities.api.inventory.gui.GuiHandler;
+import me.wolfyscript.utilities.api.inventory.gui.GuiWindow;
+import me.wolfyscript.utilities.api.inventory.gui.cache.CustomCache;
+import me.wolfyscript.utilities.api.nms.inventory.GUIInventory;
+import org.apache.commons.lang.Validate;
+import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.inventory.InventoryHolder;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class GUIInventoryCreator {
+
+    public static final GUIInventoryCreator INSTANCE = new GUIInventoryCreator();
+    private final GUICustomInventoryConverter DEFAULT_CONVERTER = new GUICustomInventoryConverter();
+    private final Map<InventoryType, InventoryConverter> converterMap = new HashMap<>();
+
+    private GUIInventoryCreator() {
+        this.converterMap.put(InventoryType.CHEST, this.DEFAULT_CONVERTER);
+        this.converterMap.put(InventoryType.DISPENSER, new GUITileInventoryConverter.Dispenser());
+        this.converterMap.put(InventoryType.DROPPER, new GUITileInventoryConverter.Dropper());
+        this.converterMap.put(InventoryType.FURNACE, new GUITileInventoryConverter.Furnace());
+        this.converterMap.put(InventoryType.WORKBENCH, this.DEFAULT_CONVERTER);
+        this.converterMap.put(InventoryType.ENCHANTING, this.DEFAULT_CONVERTER);
+        this.converterMap.put(InventoryType.BREWING, new GUITileInventoryConverter.BrewingStand());
+        this.converterMap.put(InventoryType.PLAYER, this.DEFAULT_CONVERTER);
+        this.converterMap.put(InventoryType.MERCHANT, this.DEFAULT_CONVERTER);
+        this.converterMap.put(InventoryType.ENDER_CHEST, this.DEFAULT_CONVERTER);
+        this.converterMap.put(InventoryType.ANVIL, this.DEFAULT_CONVERTER);
+        this.converterMap.put(InventoryType.SMITHING, this.DEFAULT_CONVERTER);
+        this.converterMap.put(InventoryType.BEACON, this.DEFAULT_CONVERTER);
+        this.converterMap.put(InventoryType.HOPPER, new GUITileInventoryConverter.Hopper());
+        this.converterMap.put(InventoryType.SHULKER_BOX, this.DEFAULT_CONVERTER);
+        this.converterMap.put(InventoryType.BARREL, this.DEFAULT_CONVERTER);
+        this.converterMap.put(InventoryType.BLAST_FURNACE, new GUITileInventoryConverter.BlastFurnace());
+        this.converterMap.put(InventoryType.LECTERN, new GUITileInventoryConverter.Lectern());
+        this.converterMap.put(InventoryType.SMOKER, new GUITileInventoryConverter.Smoker());
+        this.converterMap.put(InventoryType.LOOM, this.DEFAULT_CONVERTER);
+        this.converterMap.put(InventoryType.CARTOGRAPHY, this.DEFAULT_CONVERTER);
+        this.converterMap.put(InventoryType.GRINDSTONE, this.DEFAULT_CONVERTER);
+        this.converterMap.put(InventoryType.STONECUTTER, this.DEFAULT_CONVERTER);
+    }
+
+    public <C extends CustomCache> GUIInventory<C> createInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder holder, InventoryType type) {
+        Validate.isTrue(this.converterMap.containsKey(type), "Cannot create GUI inventory of type ", type);
+        return this.converterMap.get(type).createInventory(guiHandler, window, holder, type);
+    }
+
+    public <C extends CustomCache> GUIInventory<C> createInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder holder, InventoryType type, String title) {
+        Validate.isTrue(this.converterMap.containsKey(type), "Cannot create GUI inventory of type ", type);
+        return this.converterMap.get(type).createInventory(guiHandler, window, holder, type, title);
+    }
+
+    public <C extends CustomCache> GUIInventory<C> createInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder holder, int size) {
+        return this.DEFAULT_CONVERTER.createInventory(guiHandler, window, holder, size);
+    }
+
+    public <C extends CustomCache> GUIInventory<C> createInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder holder, int size, String title) {
+        return this.DEFAULT_CONVERTER.createInventory(guiHandler, window, holder, size, title);
+    }
+
+    public interface InventoryConverter {
+
+        <C extends CustomCache> GUIInventory<C> createInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder holder, InventoryType type);
+
+        <C extends CustomCache> GUIInventory<C> createInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder holder, InventoryType type, String title);
+    }
+}

--- a/nmsutil-v1_16_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_16_R2/inventory/util/GUITileInventoryConverter.java
+++ b/nmsutil-v1_16_R2/src/main/java/me/wolfyscript/utilities/api/nms/v1_16_R2/inventory/util/GUITileInventoryConverter.java
@@ -1,0 +1,126 @@
+package me.wolfyscript.utilities.api.nms.v1_16_R2.inventory.util;
+
+import me.wolfyscript.utilities.api.inventory.gui.GuiHandler;
+import me.wolfyscript.utilities.api.inventory.gui.GuiWindow;
+import me.wolfyscript.utilities.api.inventory.gui.cache.CustomCache;
+import me.wolfyscript.utilities.api.nms.inventory.GUIInventory;
+import me.wolfyscript.utilities.api.nms.v1_16_R2.inventory.GUIInventoryBrewer;
+import me.wolfyscript.utilities.api.nms.v1_16_R2.inventory.GUIInventoryFurnace;
+import me.wolfyscript.utilities.api.nms.v1_16_R2.inventory.GUIInventoryImpl;
+import net.minecraft.server.v1_16_R2.*;
+import org.bukkit.craftbukkit.v1_16_R2.util.CraftChatMessage;
+import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.inventory.InventoryHolder;
+
+public abstract class GUITileInventoryConverter implements GUIInventoryCreator.InventoryConverter {
+
+    public GUITileInventoryConverter() {
+    }
+
+    public abstract IInventory getTileEntity();
+
+    @Override
+    public <C extends CustomCache> GUIInventory<C> createInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder holder, InventoryType type) {
+        return this.getInventory(guiHandler, window, this.getTileEntity());
+    }
+
+    @Override
+    public <C extends CustomCache> GUIInventory<C> createInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder holder, InventoryType type, String title) {
+        IInventory te = this.getTileEntity();
+        if (te instanceof TileEntityLootable) {
+            ((TileEntityLootable) te).setCustomName(CraftChatMessage.fromStringOrNull(title));
+        }
+        return this.getInventory(guiHandler, window, te);
+    }
+
+    public <C extends CustomCache> GUIInventory<C> getInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, IInventory tileEntity) {
+        return new GUIInventoryImpl<>(guiHandler, window, tileEntity);
+    }
+
+    //---------------------------Sub-Classes------------------------------------
+
+    public static class BlastFurnace extends GUITileInventoryConverter {
+        @Override
+        public IInventory getTileEntity() {
+            return new TileEntityBlastFurnace();
+        }
+    }
+
+    public static class BrewingStand extends GUITileInventoryConverter {
+        @Override
+        public IInventory getTileEntity() {
+            return new TileEntityBrewingStand();
+        }
+
+        @Override
+        public <C extends CustomCache> GUIInventory<C> createInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder holder, InventoryType type, String title) {
+            IInventory tileEntity = this.getTileEntity();
+            if (tileEntity instanceof TileEntityBrewingStand) {
+                ((TileEntityBrewingStand) tileEntity).setCustomName(CraftChatMessage.fromStringOrNull(title));
+            }
+            return this.getInventory(guiHandler, window, tileEntity);
+        }
+
+        @Override
+        public <C extends CustomCache> GUIInventory<C> getInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, IInventory tileEntity) {
+            return new GUIInventoryBrewer<>(guiHandler, window, tileEntity);
+        }
+    }
+
+    public static class Dispenser extends GUITileInventoryConverter {
+        @Override
+        public IInventory getTileEntity() {
+            return new TileEntityDispenser();
+        }
+    }
+
+    public static class Dropper extends GUITileInventoryConverter {
+        @Override
+        public IInventory getTileEntity() {
+            return new TileEntityDropper();
+        }
+    }
+
+    public static class Furnace extends GUITileInventoryConverter {
+
+        @Override
+        public IInventory getTileEntity() {
+            TileEntityFurnace furnace = new TileEntityFurnaceFurnace();
+            furnace.setLocation(MinecraftServer.getServer().getWorldServer(World.OVERWORLD), BlockPosition.ZERO);
+            return furnace;
+        }
+
+        @Override
+        public <C extends CustomCache> GUIInventory<C> createInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder holder, InventoryType type, String title) {
+            IInventory tileEntity = this.getTileEntity();
+            ((TileEntityFurnace) tileEntity).setCustomName(CraftChatMessage.fromStringOrNull(title));
+            return this.getInventory(guiHandler, window, tileEntity);
+        }
+
+        @Override
+        public <C extends CustomCache> GUIInventory<C> getInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, IInventory tileEntity) {
+            return new GUIInventoryFurnace<>(guiHandler, window, (TileEntityFurnace) tileEntity);
+        }
+    }
+
+    public static class Hopper extends GUITileInventoryConverter {
+        @Override
+        public IInventory getTileEntity() {
+            return new TileEntityHopper();
+        }
+    }
+
+    public static class Lectern extends GUITileInventoryConverter {
+        @Override
+        public IInventory getTileEntity() {
+            return (new TileEntityLectern()).inventory;
+        }
+    }
+
+    public static class Smoker extends GUITileInventoryConverter {
+        @Override
+        public IInventory getTileEntity() {
+            return new TileEntitySmoker();
+        }
+    }
+}

--- a/nmsutil-v1_16_R3/src/main/java/me/wolfyscript/utilities/api/nms/v1_16_R3/InventoryUtilImpl.java
+++ b/nmsutil-v1_16_R3/src/main/java/me/wolfyscript/utilities/api/nms/v1_16_R3/InventoryUtilImpl.java
@@ -17,21 +17,21 @@ public class InventoryUtilImpl extends InventoryUtil {
 
     @Override
     public <C extends CustomCache> GUIInventory<C> createGUIInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryType type) {
-        return GUIInventoryCreator.INSTANCE.createInventory(guiHandler, window, guiHandler, type);
+        return GUIInventoryCreator.INSTANCE.createInventory(guiHandler, window, null, type);
     }
 
     @Override
     public <C extends CustomCache> GUIInventory<C> createGUIInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryType type, String title) {
-        return GUIInventoryCreator.INSTANCE.createInventory(guiHandler, window, guiHandler, type, title);
+        return GUIInventoryCreator.INSTANCE.createInventory(guiHandler, window, null, type, title);
     }
 
     @Override
     public <C extends CustomCache> GUIInventory<C> createGUIInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, int size) {
-        return GUIInventoryCreator.INSTANCE.createInventory(guiHandler, window, guiHandler, size);
+        return GUIInventoryCreator.INSTANCE.createInventory(guiHandler, window, null, size);
     }
 
     @Override
     public <C extends CustomCache> GUIInventory<C> createGUIInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, int size, String title) {
-        return GUIInventoryCreator.INSTANCE.createInventory(guiHandler, window, guiHandler, size, title);
+        return GUIInventoryCreator.INSTANCE.createInventory(guiHandler, window, null, size, title);
     }
 }

--- a/nmsutil-v1_16_R3/src/main/java/me/wolfyscript/utilities/api/nms/v1_16_R3/InventoryUtilImpl.java
+++ b/nmsutil-v1_16_R3/src/main/java/me/wolfyscript/utilities/api/nms/v1_16_R3/InventoryUtilImpl.java
@@ -1,0 +1,37 @@
+package me.wolfyscript.utilities.api.nms.v1_16_R3;
+
+import me.wolfyscript.utilities.api.inventory.gui.GuiHandler;
+import me.wolfyscript.utilities.api.inventory.gui.GuiWindow;
+import me.wolfyscript.utilities.api.inventory.gui.cache.CustomCache;
+import me.wolfyscript.utilities.api.nms.InventoryUtil;
+import me.wolfyscript.utilities.api.nms.NMSUtil;
+import me.wolfyscript.utilities.api.nms.inventory.GUIInventory;
+import me.wolfyscript.utilities.api.nms.v1_16_R3.inventory.util.GUIInventoryCreator;
+import org.bukkit.event.inventory.InventoryType;
+
+public class InventoryUtilImpl extends InventoryUtil {
+
+    protected InventoryUtilImpl(NMSUtil nmsUtil) {
+        super(nmsUtil);
+    }
+
+    @Override
+    public <C extends CustomCache> GUIInventory<C> createGUIInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryType type) {
+        return GUIInventoryCreator.INSTANCE.createInventory(guiHandler, window, guiHandler, type);
+    }
+
+    @Override
+    public <C extends CustomCache> GUIInventory<C> createGUIInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryType type, String title) {
+        return GUIInventoryCreator.INSTANCE.createInventory(guiHandler, window, guiHandler, type, title);
+    }
+
+    @Override
+    public <C extends CustomCache> GUIInventory<C> createGUIInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, int size) {
+        return GUIInventoryCreator.INSTANCE.createInventory(guiHandler, window, guiHandler, size);
+    }
+
+    @Override
+    public <C extends CustomCache> GUIInventory<C> createGUIInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, int size, String title) {
+        return GUIInventoryCreator.INSTANCE.createInventory(guiHandler, window, guiHandler, size, title);
+    }
+}

--- a/nmsutil-v1_16_R3/src/main/java/me/wolfyscript/utilities/api/nms/v1_16_R3/NMSEntry.java
+++ b/nmsutil-v1_16_R3/src/main/java/me/wolfyscript/utilities/api/nms/v1_16_R3/NMSEntry.java
@@ -2,6 +2,7 @@ package me.wolfyscript.utilities.api.nms.v1_16_R3;
 
 import me.wolfyscript.utilities.api.WolfyUtilities;
 import me.wolfyscript.utilities.api.nms.BlockUtil;
+import me.wolfyscript.utilities.api.nms.InventoryUtil;
 import me.wolfyscript.utilities.api.nms.ItemUtil;
 import me.wolfyscript.utilities.api.nms.NMSUtil;
 import org.bukkit.plugin.Plugin;
@@ -10,6 +11,7 @@ public class NMSEntry extends NMSUtil {
 
     private final BlockUtil blockUtil;
     private final ItemUtil itemUtil;
+    private final InventoryUtil inventoryUtil;
 
     /**
      * The class that implements this NMSUtil needs to have a constructor with just the {@link Plugin} parameter.
@@ -20,6 +22,7 @@ public class NMSEntry extends NMSUtil {
         super(wolfyUtilities);
         this.blockUtil = new BlockUtilImpl(this);
         this.itemUtil = new ItemUtilImpl(this);
+        this.inventoryUtil = new InventoryUtilImpl(this);
     }
 
     @Override
@@ -30,6 +33,11 @@ public class NMSEntry extends NMSUtil {
     @Override
     public ItemUtil getItemUtil() {
         return itemUtil;
+    }
+
+    @Override
+    public InventoryUtil getInventoryUtil() {
+        return this.inventoryUtil;
     }
 
 

--- a/nmsutil-v1_16_R3/src/main/java/me/wolfyscript/utilities/api/nms/v1_16_R3/inventory/GUIInventoryBrewer.java
+++ b/nmsutil-v1_16_R3/src/main/java/me/wolfyscript/utilities/api/nms/v1_16_R3/inventory/GUIInventoryBrewer.java
@@ -5,14 +5,14 @@ import me.wolfyscript.utilities.api.inventory.gui.GuiWindow;
 import me.wolfyscript.utilities.api.inventory.gui.cache.CustomCache;
 import me.wolfyscript.utilities.api.nms.inventory.GUIInventory;
 import net.minecraft.server.v1_16_R3.IInventory;
-import org.bukkit.craftbukkit.v1_16_R3.inventory.CraftInventory;
+import org.bukkit.craftbukkit.v1_16_R3.inventory.CraftInventoryBrewer;
 
-public class GUIInventoryImpl<C extends CustomCache> extends CraftInventory implements GUIInventory<C> {
+public class GUIInventoryBrewer<C extends CustomCache> extends CraftInventoryBrewer implements GUIInventory<C> {
 
     private final GuiWindow<C> window;
     private final GuiHandler<C> guiHandler;
 
-    public GUIInventoryImpl(GuiHandler<C> guiHandler, GuiWindow<C> window, IInventory inventory) {
+    public GUIInventoryBrewer(GuiHandler<C> guiHandler, GuiWindow<C> window, IInventory inventory) {
         super(inventory);
         this.guiHandler = guiHandler;
         this.window = window;

--- a/nmsutil-v1_16_R3/src/main/java/me/wolfyscript/utilities/api/nms/v1_16_R3/inventory/GUIInventoryCustom.java
+++ b/nmsutil-v1_16_R3/src/main/java/me/wolfyscript/utilities/api/nms/v1_16_R3/inventory/GUIInventoryCustom.java
@@ -1,0 +1,49 @@
+package me.wolfyscript.utilities.api.nms.v1_16_R3.inventory;
+
+import me.wolfyscript.utilities.api.inventory.gui.GuiHandler;
+import me.wolfyscript.utilities.api.inventory.gui.GuiWindow;
+import me.wolfyscript.utilities.api.inventory.gui.cache.CustomCache;
+import me.wolfyscript.utilities.api.nms.inventory.GUIInventory;
+import org.bukkit.craftbukkit.v1_16_R3.inventory.CraftInventoryCustom;
+import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.inventory.InventoryHolder;
+
+public class GUIInventoryCustom<C extends CustomCache> extends CraftInventoryCustom implements GUIInventory<C> {
+
+    private final GuiWindow<C> window;
+    private final GuiHandler<C> guiHandler;
+
+    public GUIInventoryCustom(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder owner, InventoryType type) {
+        super(owner, type);
+        this.guiHandler = guiHandler;
+        this.window = window;
+    }
+
+    public GUIInventoryCustom(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder owner, InventoryType type, String title) {
+        super(owner, type, title);
+        this.guiHandler = guiHandler;
+        this.window = window;
+    }
+
+    public GUIInventoryCustom(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder owner, int size) {
+        super(owner, size);
+        this.guiHandler = guiHandler;
+        this.window = window;
+    }
+
+    public GUIInventoryCustom(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder owner, int size, String title) {
+        super(owner, size, title);
+        this.guiHandler = guiHandler;
+        this.window = window;
+    }
+
+    @Override
+    public GuiWindow<C> getWindow() {
+        return this.window;
+    }
+
+    @Override
+    public GuiHandler<C> getGuiHandler() {
+        return guiHandler;
+    }
+}

--- a/nmsutil-v1_16_R3/src/main/java/me/wolfyscript/utilities/api/nms/v1_16_R3/inventory/GUIInventoryFurnace.java
+++ b/nmsutil-v1_16_R3/src/main/java/me/wolfyscript/utilities/api/nms/v1_16_R3/inventory/GUIInventoryFurnace.java
@@ -4,15 +4,15 @@ import me.wolfyscript.utilities.api.inventory.gui.GuiHandler;
 import me.wolfyscript.utilities.api.inventory.gui.GuiWindow;
 import me.wolfyscript.utilities.api.inventory.gui.cache.CustomCache;
 import me.wolfyscript.utilities.api.nms.inventory.GUIInventory;
-import net.minecraft.server.v1_16_R3.IInventory;
-import org.bukkit.craftbukkit.v1_16_R3.inventory.CraftInventory;
+import net.minecraft.server.v1_16_R3.TileEntityFurnace;
+import org.bukkit.craftbukkit.v1_16_R3.inventory.CraftInventoryFurnace;
 
-public class GUIInventoryImpl<C extends CustomCache> extends CraftInventory implements GUIInventory<C> {
+public class GUIInventoryFurnace<C extends CustomCache> extends CraftInventoryFurnace implements GUIInventory<C> {
 
     private final GuiWindow<C> window;
     private final GuiHandler<C> guiHandler;
 
-    public GUIInventoryImpl(GuiHandler<C> guiHandler, GuiWindow<C> window, IInventory inventory) {
+    public GUIInventoryFurnace(GuiHandler<C> guiHandler, GuiWindow<C> window, TileEntityFurnace inventory) {
         super(inventory);
         this.guiHandler = guiHandler;
         this.window = window;

--- a/nmsutil-v1_16_R3/src/main/java/me/wolfyscript/utilities/api/nms/v1_16_R3/inventory/GUIInventoryImpl.java
+++ b/nmsutil-v1_16_R3/src/main/java/me/wolfyscript/utilities/api/nms/v1_16_R3/inventory/GUIInventoryImpl.java
@@ -1,0 +1,49 @@
+package me.wolfyscript.utilities.api.nms.v1_16_R3.inventory;
+
+import me.wolfyscript.utilities.api.inventory.gui.GuiHandler;
+import me.wolfyscript.utilities.api.inventory.gui.GuiWindow;
+import me.wolfyscript.utilities.api.inventory.gui.cache.CustomCache;
+import me.wolfyscript.utilities.api.nms.inventory.GUIInventory;
+import org.bukkit.craftbukkit.v1_16_R3.inventory.CraftInventoryCustom;
+import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.inventory.InventoryHolder;
+
+public class GUIInventoryImpl<C extends CustomCache> extends CraftInventoryCustom implements GUIInventory<C> {
+
+    private final GuiWindow<C> window;
+    private final GuiHandler<C> guiHandler;
+
+    public GUIInventoryImpl(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder owner, InventoryType type) {
+        super(owner, type);
+        this.guiHandler = guiHandler;
+        this.window = window;
+    }
+
+    public GUIInventoryImpl(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder owner, InventoryType type, String title) {
+        super(owner, type, title);
+        this.guiHandler = guiHandler;
+        this.window = window;
+    }
+
+    public GUIInventoryImpl(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder owner, int size) {
+        super(owner, size);
+        this.guiHandler = guiHandler;
+        this.window = window;
+    }
+
+    public GUIInventoryImpl(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder owner, int size, String title) {
+        super(owner, size, title);
+        this.guiHandler = guiHandler;
+        this.window = window;
+    }
+
+    @Override
+    public GuiWindow<C> getWindow() {
+        return this.window;
+    }
+
+    @Override
+    public GuiHandler<C> getGuiHandler() {
+        return guiHandler;
+    }
+}

--- a/nmsutil-v1_16_R3/src/main/java/me/wolfyscript/utilities/api/nms/v1_16_R3/inventory/util/GUICustomInventoryConverter.java
+++ b/nmsutil-v1_16_R3/src/main/java/me/wolfyscript/utilities/api/nms/v1_16_R3/inventory/util/GUICustomInventoryConverter.java
@@ -4,7 +4,7 @@ import me.wolfyscript.utilities.api.inventory.gui.GuiHandler;
 import me.wolfyscript.utilities.api.inventory.gui.GuiWindow;
 import me.wolfyscript.utilities.api.inventory.gui.cache.CustomCache;
 import me.wolfyscript.utilities.api.nms.inventory.GUIInventory;
-import me.wolfyscript.utilities.api.nms.v1_16_R3.inventory.GUIInventoryImpl;
+import me.wolfyscript.utilities.api.nms.v1_16_R3.inventory.GUIInventoryCustom;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.inventory.InventoryHolder;
 
@@ -15,19 +15,19 @@ public class GUICustomInventoryConverter implements GUIInventoryCreator.Inventor
 
     @Override
     public <C extends CustomCache> GUIInventory<C> createInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder holder, InventoryType type) {
-        return new GUIInventoryImpl<>(guiHandler, window, holder, type);
+        return new GUIInventoryCustom<>(guiHandler, window, holder, type);
     }
 
     @Override
     public <C extends CustomCache> GUIInventory<C> createInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder holder, InventoryType type, String title) {
-        return new GUIInventoryImpl<>(guiHandler, window, holder, type, title);
+        return new GUIInventoryCustom<>(guiHandler, window, holder, type, title);
     }
 
     public <C extends CustomCache> GUIInventory<C> createInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder owner, int size) {
-        return new GUIInventoryImpl<>(guiHandler, window, owner, size);
+        return new GUIInventoryCustom<>(guiHandler, window, owner, size);
     }
 
     public <C extends CustomCache> GUIInventory<C> createInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder owner, int size, String title) {
-        return new GUIInventoryImpl<>(guiHandler, window, owner, size, title);
+        return new GUIInventoryCustom<>(guiHandler, window, owner, size, title);
     }
 }

--- a/nmsutil-v1_16_R3/src/main/java/me/wolfyscript/utilities/api/nms/v1_16_R3/inventory/util/GUICustomInventoryConverter.java
+++ b/nmsutil-v1_16_R3/src/main/java/me/wolfyscript/utilities/api/nms/v1_16_R3/inventory/util/GUICustomInventoryConverter.java
@@ -1,0 +1,33 @@
+package me.wolfyscript.utilities.api.nms.v1_16_R3.inventory.util;
+
+import me.wolfyscript.utilities.api.inventory.gui.GuiHandler;
+import me.wolfyscript.utilities.api.inventory.gui.GuiWindow;
+import me.wolfyscript.utilities.api.inventory.gui.cache.CustomCache;
+import me.wolfyscript.utilities.api.nms.inventory.GUIInventory;
+import me.wolfyscript.utilities.api.nms.v1_16_R3.inventory.GUIInventoryImpl;
+import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.inventory.InventoryHolder;
+
+public class GUICustomInventoryConverter implements GUIInventoryCreator.InventoryConverter {
+
+    public GUICustomInventoryConverter() {
+    }
+
+    @Override
+    public <C extends CustomCache> GUIInventory<C> createInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder holder, InventoryType type) {
+        return new GUIInventoryImpl<>(guiHandler, window, holder, type);
+    }
+
+    @Override
+    public <C extends CustomCache> GUIInventory<C> createInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder holder, InventoryType type, String title) {
+        return new GUIInventoryImpl<>(guiHandler, window, holder, type, title);
+    }
+
+    public <C extends CustomCache> GUIInventory<C> createInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder owner, int size) {
+        return new GUIInventoryImpl<>(guiHandler, window, owner, size);
+    }
+
+    public <C extends CustomCache> GUIInventory<C> createInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder owner, int size, String title) {
+        return new GUIInventoryImpl<>(guiHandler, window, owner, size, title);
+    }
+}

--- a/nmsutil-v1_16_R3/src/main/java/me/wolfyscript/utilities/api/nms/v1_16_R3/inventory/util/GUIInventoryCreator.java
+++ b/nmsutil-v1_16_R3/src/main/java/me/wolfyscript/utilities/api/nms/v1_16_R3/inventory/util/GUIInventoryCreator.java
@@ -1,0 +1,71 @@
+package me.wolfyscript.utilities.api.nms.v1_16_R3.inventory.util;
+
+import me.wolfyscript.utilities.api.inventory.gui.GuiHandler;
+import me.wolfyscript.utilities.api.inventory.gui.GuiWindow;
+import me.wolfyscript.utilities.api.inventory.gui.cache.CustomCache;
+import me.wolfyscript.utilities.api.nms.inventory.GUIInventory;
+import org.apache.commons.lang.Validate;
+import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.inventory.InventoryHolder;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class GUIInventoryCreator {
+
+    public static final GUIInventoryCreator INSTANCE = new GUIInventoryCreator();
+    private final GUICustomInventoryConverter DEFAULT_CONVERTER = new GUICustomInventoryConverter();
+    private final Map<InventoryType, GUIInventoryCreator.InventoryConverter> converterMap = new HashMap<>();
+
+    private GUIInventoryCreator() {
+        this.converterMap.put(InventoryType.CHEST, this.DEFAULT_CONVERTER);
+        //this.converterMap.put(InventoryType.DISPENSER, new CraftTileInventoryConverter.Dispenser());
+        //this.converterMap.put(InventoryType.DROPPER, new CraftTileInventoryConverter.Dropper());
+        //this.converterMap.put(InventoryType.FURNACE, new CraftTileInventoryConverter.Furnace());
+        this.converterMap.put(InventoryType.WORKBENCH, this.DEFAULT_CONVERTER);
+        this.converterMap.put(InventoryType.ENCHANTING, this.DEFAULT_CONVERTER);
+        //this.converterMap.put(InventoryType.BREWING, new CraftTileInventoryConverter.BrewingStand());
+        this.converterMap.put(InventoryType.PLAYER, this.DEFAULT_CONVERTER);
+        this.converterMap.put(InventoryType.MERCHANT, this.DEFAULT_CONVERTER);
+        this.converterMap.put(InventoryType.ENDER_CHEST, this.DEFAULT_CONVERTER);
+        this.converterMap.put(InventoryType.ANVIL, this.DEFAULT_CONVERTER);
+        this.converterMap.put(InventoryType.SMITHING, this.DEFAULT_CONVERTER);
+        this.converterMap.put(InventoryType.BEACON, this.DEFAULT_CONVERTER);
+        //this.converterMap.put(InventoryType.HOPPER, new CraftTileInventoryConverter.Hopper());
+        this.converterMap.put(InventoryType.SHULKER_BOX, this.DEFAULT_CONVERTER);
+        this.converterMap.put(InventoryType.BARREL, this.DEFAULT_CONVERTER);
+        //this.converterMap.put(InventoryType.BLAST_FURNACE, new CraftTileInventoryConverter.BlastFurnace());
+        //this.converterMap.put(InventoryType.LECTERN, new CraftTileInventoryConverter.Lectern());
+        //this.converterMap.put(InventoryType.SMOKER, new CraftTileInventoryConverter.Smoker());
+        this.converterMap.put(InventoryType.LOOM, this.DEFAULT_CONVERTER);
+        this.converterMap.put(InventoryType.CARTOGRAPHY, this.DEFAULT_CONVERTER);
+        this.converterMap.put(InventoryType.GRINDSTONE, this.DEFAULT_CONVERTER);
+        this.converterMap.put(InventoryType.STONECUTTER, this.DEFAULT_CONVERTER);
+    }
+
+    public <C extends CustomCache> GUIInventory<C> createInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder holder, InventoryType type) {
+        Validate.isTrue(this.converterMap.containsKey(type), "Cannot create GUI inventory of type ", type);
+        return this.converterMap.get(type).createInventory(guiHandler, window, holder, type);
+    }
+
+    public <C extends CustomCache> GUIInventory<C> createInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder holder, InventoryType type, String title) {
+        //Missing type converter might be added soon!
+        Validate.isTrue(this.converterMap.containsKey(type), "Cannot create GUI inventory of type ", type);
+        return this.converterMap.get(type).createInventory(guiHandler, window, holder, type, title);
+    }
+
+    public <C extends CustomCache> GUIInventory<C> createInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder holder, int size) {
+        return this.DEFAULT_CONVERTER.createInventory(guiHandler, window, holder, size);
+    }
+
+    public <C extends CustomCache> GUIInventory<C> createInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder holder, int size, String title) {
+        return this.DEFAULT_CONVERTER.createInventory(guiHandler, window, holder, size, title);
+    }
+
+    public interface InventoryConverter {
+
+        <C extends CustomCache> GUIInventory<C> createInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder holder, InventoryType type);
+
+        <C extends CustomCache> GUIInventory<C> createInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder holder, InventoryType type, String title);
+    }
+}

--- a/nmsutil-v1_16_R3/src/main/java/me/wolfyscript/utilities/api/nms/v1_16_R3/inventory/util/GUIInventoryCreator.java
+++ b/nmsutil-v1_16_R3/src/main/java/me/wolfyscript/utilities/api/nms/v1_16_R3/inventory/util/GUIInventoryCreator.java
@@ -19,24 +19,24 @@ public class GUIInventoryCreator {
 
     private GUIInventoryCreator() {
         this.converterMap.put(InventoryType.CHEST, this.DEFAULT_CONVERTER);
-        //this.converterMap.put(InventoryType.DISPENSER, new CraftTileInventoryConverter.Dispenser());
-        //this.converterMap.put(InventoryType.DROPPER, new CraftTileInventoryConverter.Dropper());
-        //this.converterMap.put(InventoryType.FURNACE, new CraftTileInventoryConverter.Furnace());
+        this.converterMap.put(InventoryType.DISPENSER, new GUITileInventoryConverter.Dispenser());
+        this.converterMap.put(InventoryType.DROPPER, new GUITileInventoryConverter.Dropper());
+        this.converterMap.put(InventoryType.FURNACE, new GUITileInventoryConverter.Furnace());
         this.converterMap.put(InventoryType.WORKBENCH, this.DEFAULT_CONVERTER);
         this.converterMap.put(InventoryType.ENCHANTING, this.DEFAULT_CONVERTER);
-        //this.converterMap.put(InventoryType.BREWING, new CraftTileInventoryConverter.BrewingStand());
+        this.converterMap.put(InventoryType.BREWING, new GUITileInventoryConverter.BrewingStand());
         this.converterMap.put(InventoryType.PLAYER, this.DEFAULT_CONVERTER);
         this.converterMap.put(InventoryType.MERCHANT, this.DEFAULT_CONVERTER);
         this.converterMap.put(InventoryType.ENDER_CHEST, this.DEFAULT_CONVERTER);
         this.converterMap.put(InventoryType.ANVIL, this.DEFAULT_CONVERTER);
         this.converterMap.put(InventoryType.SMITHING, this.DEFAULT_CONVERTER);
         this.converterMap.put(InventoryType.BEACON, this.DEFAULT_CONVERTER);
-        //this.converterMap.put(InventoryType.HOPPER, new CraftTileInventoryConverter.Hopper());
+        this.converterMap.put(InventoryType.HOPPER, new GUITileInventoryConverter.Hopper());
         this.converterMap.put(InventoryType.SHULKER_BOX, this.DEFAULT_CONVERTER);
         this.converterMap.put(InventoryType.BARREL, this.DEFAULT_CONVERTER);
-        //this.converterMap.put(InventoryType.BLAST_FURNACE, new CraftTileInventoryConverter.BlastFurnace());
-        //this.converterMap.put(InventoryType.LECTERN, new CraftTileInventoryConverter.Lectern());
-        //this.converterMap.put(InventoryType.SMOKER, new CraftTileInventoryConverter.Smoker());
+        this.converterMap.put(InventoryType.BLAST_FURNACE, new GUITileInventoryConverter.BlastFurnace());
+        this.converterMap.put(InventoryType.LECTERN, new GUITileInventoryConverter.Lectern());
+        this.converterMap.put(InventoryType.SMOKER, new GUITileInventoryConverter.Smoker());
         this.converterMap.put(InventoryType.LOOM, this.DEFAULT_CONVERTER);
         this.converterMap.put(InventoryType.CARTOGRAPHY, this.DEFAULT_CONVERTER);
         this.converterMap.put(InventoryType.GRINDSTONE, this.DEFAULT_CONVERTER);
@@ -49,7 +49,6 @@ public class GUIInventoryCreator {
     }
 
     public <C extends CustomCache> GUIInventory<C> createInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder holder, InventoryType type, String title) {
-        //Missing type converter might be added soon!
         Validate.isTrue(this.converterMap.containsKey(type), "Cannot create GUI inventory of type ", type);
         return this.converterMap.get(type).createInventory(guiHandler, window, holder, type, title);
     }

--- a/nmsutil-v1_16_R3/src/main/java/me/wolfyscript/utilities/api/nms/v1_16_R3/inventory/util/GUITileInventoryConverter.java
+++ b/nmsutil-v1_16_R3/src/main/java/me/wolfyscript/utilities/api/nms/v1_16_R3/inventory/util/GUITileInventoryConverter.java
@@ -1,13 +1,15 @@
 package me.wolfyscript.utilities.api.nms.v1_16_R3.inventory.util;
 
+import me.wolfyscript.utilities.api.inventory.gui.GuiHandler;
+import me.wolfyscript.utilities.api.inventory.gui.GuiWindow;
+import me.wolfyscript.utilities.api.inventory.gui.cache.CustomCache;
+import me.wolfyscript.utilities.api.nms.inventory.GUIInventory;
+import me.wolfyscript.utilities.api.nms.v1_16_R3.inventory.GUIInventoryBrewer;
+import me.wolfyscript.utilities.api.nms.v1_16_R3.inventory.GUIInventoryFurnace;
+import me.wolfyscript.utilities.api.nms.v1_16_R3.inventory.GUIInventoryImpl;
 import net.minecraft.server.v1_16_R3.*;
-import org.bukkit.craftbukkit.v1_16_R3.inventory.CraftInventory;
-import org.bukkit.craftbukkit.v1_16_R3.inventory.CraftInventoryBrewer;
-import org.bukkit.craftbukkit.v1_16_R3.inventory.CraftInventoryFurnace;
-import org.bukkit.craftbukkit.v1_16_R3.inventory.util.CraftTileInventoryConverter;
 import org.bukkit.craftbukkit.v1_16_R3.util.CraftChatMessage;
 import org.bukkit.event.inventory.InventoryType;
-import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
 
 public abstract class GUITileInventoryConverter implements GUIInventoryCreator.InventoryConverter {
@@ -17,115 +19,106 @@ public abstract class GUITileInventoryConverter implements GUIInventoryCreator.I
 
     public abstract IInventory getTileEntity();
 
-    public Inventory createInventory(InventoryHolder holder, InventoryType type) {
-        return this.getInventory(this.getTileEntity());
+    @Override
+    public <C extends CustomCache> GUIInventory<C> createInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder holder, InventoryType type) {
+        return this.getInventory(guiHandler, window, this.getTileEntity());
     }
 
-    public Inventory createInventory(InventoryHolder holder, InventoryType type, String title) {
+    @Override
+    public <C extends CustomCache> GUIInventory<C> createInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder holder, InventoryType type, String title) {
         IInventory te = this.getTileEntity();
         if (te instanceof TileEntityLootable) {
             ((TileEntityLootable) te).setCustomName(CraftChatMessage.fromStringOrNull(title));
         }
-
-        return this.getInventory(te);
+        return this.getInventory(guiHandler, window, te);
     }
 
-    public Inventory getInventory(IInventory tileEntity) {
-        return new CraftInventory(tileEntity);
+    public <C extends CustomCache> GUIInventory<C> getInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, IInventory tileEntity) {
+        return new GUIInventoryImpl<>(guiHandler, window, tileEntity);
     }
 
-    public static class BlastFurnace extends CraftTileInventoryConverter {
-        public BlastFurnace() {
-        }
+    //---------------------------Sub-Classes------------------------------------
 
+    public static class BlastFurnace extends GUITileInventoryConverter {
+        @Override
         public IInventory getTileEntity() {
             return new TileEntityBlastFurnace();
         }
     }
 
-    public static class BrewingStand extends CraftTileInventoryConverter {
-        public BrewingStand() {
-        }
-
+    public static class BrewingStand extends GUITileInventoryConverter {
+        @Override
         public IInventory getTileEntity() {
             return new TileEntityBrewingStand();
         }
 
-        public Inventory createInventory(InventoryHolder holder, InventoryType type, String title) {
+        @Override
+        public <C extends CustomCache> GUIInventory<C> createInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder holder, InventoryType type, String title) {
             IInventory tileEntity = this.getTileEntity();
             if (tileEntity instanceof TileEntityBrewingStand) {
                 ((TileEntityBrewingStand) tileEntity).setCustomName(CraftChatMessage.fromStringOrNull(title));
             }
-
-            return this.getInventory(tileEntity);
+            return this.getInventory(guiHandler, window, tileEntity);
         }
 
-        public Inventory getInventory(IInventory tileEntity) {
-            return new CraftInventoryBrewer(tileEntity);
+        @Override
+        public <C extends CustomCache> GUIInventory<C> getInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, IInventory tileEntity) {
+            return new GUIInventoryBrewer<>(guiHandler, window, tileEntity);
         }
     }
 
-    public static class Dispenser extends CraftTileInventoryConverter {
-        public Dispenser() {
-        }
-
+    public static class Dispenser extends GUITileInventoryConverter {
+        @Override
         public IInventory getTileEntity() {
             return new TileEntityDispenser();
         }
     }
 
-    public static class Dropper extends CraftTileInventoryConverter {
-        public Dropper() {
-        }
-
+    public static class Dropper extends GUITileInventoryConverter {
+        @Override
         public IInventory getTileEntity() {
             return new TileEntityDropper();
         }
     }
 
-    public static class Furnace extends CraftTileInventoryConverter {
-        public Furnace() {
-        }
+    public static class Furnace extends GUITileInventoryConverter {
 
+        @Override
         public IInventory getTileEntity() {
             TileEntityFurnace furnace = new TileEntityFurnaceFurnace();
             furnace.setLocation(MinecraftServer.getServer().getWorldServer(World.OVERWORLD), BlockPosition.ZERO);
             return furnace;
         }
 
-        public Inventory createInventory(InventoryHolder owner, InventoryType type, String title) {
+        @Override
+        public <C extends CustomCache> GUIInventory<C> createInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, InventoryHolder holder, InventoryType type, String title) {
             IInventory tileEntity = this.getTileEntity();
             ((TileEntityFurnace) tileEntity).setCustomName(CraftChatMessage.fromStringOrNull(title));
-            return this.getInventory(tileEntity);
+            return this.getInventory(guiHandler, window, tileEntity);
         }
 
-        public Inventory getInventory(IInventory tileEntity) {
-            return new CraftInventoryFurnace((TileEntityFurnace) tileEntity);
+        @Override
+        public <C extends CustomCache> GUIInventory<C> getInventory(GuiHandler<C> guiHandler, GuiWindow<C> window, IInventory tileEntity) {
+            return new GUIInventoryFurnace<>(guiHandler, window, (TileEntityFurnace) tileEntity);
         }
     }
 
-    public static class Hopper extends CraftTileInventoryConverter {
-        public Hopper() {
-        }
-
+    public static class Hopper extends GUITileInventoryConverter {
+        @Override
         public IInventory getTileEntity() {
             return new TileEntityHopper();
         }
     }
 
-    public static class Lectern extends CraftTileInventoryConverter {
-        public Lectern() {
-        }
-
+    public static class Lectern extends GUITileInventoryConverter {
+        @Override
         public IInventory getTileEntity() {
             return (new TileEntityLectern()).inventory;
         }
     }
 
-    public static class Smoker extends CraftTileInventoryConverter {
-        public Smoker() {
-        }
-
+    public static class Smoker extends GUITileInventoryConverter {
+        @Override
         public IInventory getTileEntity() {
             return new TileEntitySmoker();
         }

--- a/nmsutil-v1_16_R3/src/main/java/me/wolfyscript/utilities/api/nms/v1_16_R3/inventory/util/GUITileInventoryConverter.java
+++ b/nmsutil-v1_16_R3/src/main/java/me/wolfyscript/utilities/api/nms/v1_16_R3/inventory/util/GUITileInventoryConverter.java
@@ -1,0 +1,133 @@
+package me.wolfyscript.utilities.api.nms.v1_16_R3.inventory.util;
+
+import net.minecraft.server.v1_16_R3.*;
+import org.bukkit.craftbukkit.v1_16_R3.inventory.CraftInventory;
+import org.bukkit.craftbukkit.v1_16_R3.inventory.CraftInventoryBrewer;
+import org.bukkit.craftbukkit.v1_16_R3.inventory.CraftInventoryFurnace;
+import org.bukkit.craftbukkit.v1_16_R3.inventory.util.CraftTileInventoryConverter;
+import org.bukkit.craftbukkit.v1_16_R3.util.CraftChatMessage;
+import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+
+public abstract class GUITileInventoryConverter implements GUIInventoryCreator.InventoryConverter {
+
+    public GUITileInventoryConverter() {
+    }
+
+    public abstract IInventory getTileEntity();
+
+    public Inventory createInventory(InventoryHolder holder, InventoryType type) {
+        return this.getInventory(this.getTileEntity());
+    }
+
+    public Inventory createInventory(InventoryHolder holder, InventoryType type, String title) {
+        IInventory te = this.getTileEntity();
+        if (te instanceof TileEntityLootable) {
+            ((TileEntityLootable) te).setCustomName(CraftChatMessage.fromStringOrNull(title));
+        }
+
+        return this.getInventory(te);
+    }
+
+    public Inventory getInventory(IInventory tileEntity) {
+        return new CraftInventory(tileEntity);
+    }
+
+    public static class BlastFurnace extends CraftTileInventoryConverter {
+        public BlastFurnace() {
+        }
+
+        public IInventory getTileEntity() {
+            return new TileEntityBlastFurnace();
+        }
+    }
+
+    public static class BrewingStand extends CraftTileInventoryConverter {
+        public BrewingStand() {
+        }
+
+        public IInventory getTileEntity() {
+            return new TileEntityBrewingStand();
+        }
+
+        public Inventory createInventory(InventoryHolder holder, InventoryType type, String title) {
+            IInventory tileEntity = this.getTileEntity();
+            if (tileEntity instanceof TileEntityBrewingStand) {
+                ((TileEntityBrewingStand) tileEntity).setCustomName(CraftChatMessage.fromStringOrNull(title));
+            }
+
+            return this.getInventory(tileEntity);
+        }
+
+        public Inventory getInventory(IInventory tileEntity) {
+            return new CraftInventoryBrewer(tileEntity);
+        }
+    }
+
+    public static class Dispenser extends CraftTileInventoryConverter {
+        public Dispenser() {
+        }
+
+        public IInventory getTileEntity() {
+            return new TileEntityDispenser();
+        }
+    }
+
+    public static class Dropper extends CraftTileInventoryConverter {
+        public Dropper() {
+        }
+
+        public IInventory getTileEntity() {
+            return new TileEntityDropper();
+        }
+    }
+
+    public static class Furnace extends CraftTileInventoryConverter {
+        public Furnace() {
+        }
+
+        public IInventory getTileEntity() {
+            TileEntityFurnace furnace = new TileEntityFurnaceFurnace();
+            furnace.setLocation(MinecraftServer.getServer().getWorldServer(World.OVERWORLD), BlockPosition.ZERO);
+            return furnace;
+        }
+
+        public Inventory createInventory(InventoryHolder owner, InventoryType type, String title) {
+            IInventory tileEntity = this.getTileEntity();
+            ((TileEntityFurnace) tileEntity).setCustomName(CraftChatMessage.fromStringOrNull(title));
+            return this.getInventory(tileEntity);
+        }
+
+        public Inventory getInventory(IInventory tileEntity) {
+            return new CraftInventoryFurnace((TileEntityFurnace) tileEntity);
+        }
+    }
+
+    public static class Hopper extends CraftTileInventoryConverter {
+        public Hopper() {
+        }
+
+        public IInventory getTileEntity() {
+            return new TileEntityHopper();
+        }
+    }
+
+    public static class Lectern extends CraftTileInventoryConverter {
+        public Lectern() {
+        }
+
+        public IInventory getTileEntity() {
+            return (new TileEntityLectern()).inventory;
+        }
+    }
+
+    public static class Smoker extends CraftTileInventoryConverter {
+        public Smoker() {
+        }
+
+        public IInventory getTileEntity() {
+            return new TileEntitySmoker();
+        }
+    }
+}

--- a/wolfyutilities/wolfyutilities.iml
+++ b/wolfyutilities/wolfyutilities.iml
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" type="JAVA_MODULE" version="4">
+  <component name="FacetManager">
+    <facet type="minecraft" name="Minecraft">
+      <configuration>
+        <autoDetectTypes>
+          <platformType>SPIGOT</platformType>
+        </autoDetectTypes>
+      </configuration>
+    </facet>
+  </component>
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_8">
+    <output url="file://$MODULE_DIR$/target/classes" />
+    <output-test url="file://$MODULE_DIR$/target/test-classes" />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/src/main/resources" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
+      <excludeFolder url="file://$MODULE_DIR$/target" />
+    </content>
+    <orderEntry type="jdk" jdkName="1.8" jdkType="JavaSDK" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="module" module-name="core" />
+    <orderEntry type="library" name="Maven: org.bstats:bstats-bukkit:1.7" level="project" />
+    <orderEntry type="library" name="Maven: com.fasterxml.jackson.core:jackson-databind:2.11.0" level="project" />
+    <orderEntry type="library" name="Maven: com.fasterxml.jackson.core:jackson-annotations:2.11.0" level="project" />
+    <orderEntry type="library" name="Maven: com.fasterxml.jackson.core:jackson-core:2.11.0" level="project" />
+    <orderEntry type="module" module-name="nmsutil-v1_14_R1" />
+    <orderEntry type="module" module-name="nmsutil-v1_15_R1" />
+    <orderEntry type="module" module-name="nmsutil-v1_16_R1" />
+    <orderEntry type="module" module-name="nmsutil-v1_16_R2" />
+    <orderEntry type="module" module-name="nmsutil-v1_16_R3" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.spigotmc:spigot-api:1.16.4-R0.1-SNAPSHOT" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: commons-lang:commons-lang:2.6" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.google.guava:guava:21.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.google.code.gson:gson:2.8.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: net.md-5:bungeecord-chat:1.16-R0.3" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.yaml:snakeyaml:1.26" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.spigotmc:spigot-api:javadoc:1.16.4-R0.1-SNAPSHOT" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.spigotmc:spigot-api:sources:1.16.4-R0.1-SNAPSHOT" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.jetbrains:annotations:19.0.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.mojang:authlib:1.5.21" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.commons:commons-lang3:3.3.2" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.logging.log4j:log4j-core:2.0-beta9" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: commons-codec:commons-codec:1.9" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.logging.log4j:log4j-api:2.0-beta9" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.google.code.findbugs:jsr305:2.0.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: commons-io:commons-io:2.4" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: io.netty:netty-all:5.0.0.Alpha2" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: de.iani.cubeside:LWC:5.0.16-SNAPSHOT" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.sk89q.worldedit:worldedit-bukkit:7.1.0-SNAPSHOT" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.sk89q.worldedit:worldedit-core:7.1.0-SNAPSHOT" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.sk89q.worldedit.worldedit-libs:core:7.1.0-SNAPSHOT" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: de.schlichtherle:truezip:6.8.3" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: net.java.truevfs:truevfs-profile-default_2.13:0.12.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.scala-lang:scala-library:2.13.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: net.java.truevfs:truevfs-driver-http:0.12.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: net.java.truevfs:truevfs-kernel-spec:0.12.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: net.java.truecommons:truecommons-annotations:2.5.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.google.code.findbugs:annotations:3.0.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: net.java.truecommons:truecommons-cio:2.5.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: net.java.truecommons:truecommons-io:2.5.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: net.java.truecommons:truecommons-services:2.5.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: net.java.truecommons:truecommons-logging:2.5.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: javax.inject:javax.inject:1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.httpcomponents:httpclient:4.5.10" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.httpcomponents:httpcore:4.4.12" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.slf4j:jcl-over-slf4j:1.7.28" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: net.java.truevfs:truevfs-driver-odf:0.12.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: net.java.truevfs:truevfs-comp-zipdriver:0.12.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: net.java.truevfs:truevfs-comp-zip:0.12.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.bouncycastle:bcprov-jdk15on:1.63" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: net.java.truevfs:truevfs-driver-tar:0.12.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: net.java.truevfs:truevfs-comp-tardriver:0.12.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.commons:commons-compress:1.19" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: net.java.truevfs:truevfs-driver-tar-bzip2:0.12.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: net.java.truevfs:truevfs-driver-tar-gzip:0.12.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: net.java.truevfs:truevfs-driver-tar-xz:0.12.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.tukaani:xz:1.8" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: net.java.truevfs:truevfs-driver-zip-raes:0.12.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: net.java.truevfs:truevfs-profile-base_2.13:0.12.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: net.java.truevfs:truevfs-access-swing:0.12.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: net.java.truevfs:truevfs-access:0.12.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: net.java.truevfs:truevfs-driver-file:0.12.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: net.java.truevfs:truevfs-driver-jar:0.12.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: net.java.truevfs:truevfs-driver-zip:0.12.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: net.java.truevfs:truevfs-comp-ibm437:0.12.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: net.java.truevfs:truevfs-kernel-impl_2.13:0.12.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: net.java.truecommons:truecommons-key-console:2.5.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: net.java.truecommons:truecommons-key-default:2.5.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: net.java.truecommons:truecommons-key-swing:2.5.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: net.java.truecommons:truecommons-key-macosx:2.5.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: net.java.truecommons:truecommons-key-spec:2.5.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: net.java.truecommons:truecommons-shed:2.5.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: net.java.dev.jna:jna:4.1.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.mozilla:rhino:1.7.11" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.slf4j:slf4j-api:1.7.26" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: it.unimi.dsi:fastutil:8.2.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.antlr:antlr4-runtime:4.7.2" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.sk89q.worldedit.worldedit-libs:bukkit:7.1.0-SNAPSHOT" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.bukkit:bukkit:1.13.2-R0.1-SNAPSHOT" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.googlecode.json-simple:json-simple:1.1.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: io.papermc:paperlib:1.0.2" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.logging.log4j:log4j-slf4j-impl:2.8.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.sk89q.worldguard:worldguard-bukkit:7.0.1-SNAPSHOT" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.plotsquared:PlotSquared-Core:5.13.3" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.plotsquared:PlotSquared-Bukkit:5.13.3" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.gmail.nossr50.mcMMO:mcMMO:2.1.139-SNAPSHOT" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.maven.scm:maven-scm-provider-gitexe:1.8.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: regexp:regexp:1.3" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.maven.scm:maven-scm-provider-git-commons:1.8.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.maven.scm:maven-scm-api:1.8.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.codehaus.plexus:plexus-utils:3.0.7" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.sk89q.worldguard:worldguard-core:7.0.1-SNAPSHOT" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.sk89q.worldguard.worldguard-libs:core:7.0.1-SNAPSHOT" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.flywaydb:flyway-core:3.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.sk89q.worldguard:worldguard-legacy:7.0.0-SNAPSHOT" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.sk89q:commandbook:2.3" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: io.lumine.xikage:mythicmobs:4.10.1" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: io.th0rgal:oraxen:1.40.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: dev.lone:itemsadder:2.1.5" level="project" />
+  </component>
+</module>


### PR DESCRIPTION
**Complete overhaul of the GUIs and inventories.**

GUI inventories are now based on internal CraftBukkit and Minecraft classes, providing a lot more possibilities and flexibility and full combatibillity with bukkits and spigots events and APIs.
Other than a custom InventoryHolder this even provides the required information if you use a inventory type that doesn't support InventoryHolders, which allows you to use any type of inventory as a GUI.

Caching of the players inventory is no longer required as the custom Inventory contains all the required objects and is directly recieved via Bukkits inventory events.

This overhaul makes the GUIs a lot more responsive and smoother, because of less code and checks required on each inventory click.