### PR TITLE
Replaced custom serializer/deserializer of CustomItem with JacksonAnnotations

### DIFF
--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/CustomData.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/CustomData.java
@@ -4,15 +4,21 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonTypeIdResolver;
+import com.fasterxml.jackson.databind.annotation.JsonTypeResolver;
 import me.wolfyscript.utilities.util.Keyed;
 import me.wolfyscript.utilities.util.NamespacedKey;
+import me.wolfyscript.utilities.util.json.jackson.KeyedTypeIdResolver;
+import me.wolfyscript.utilities.util.json.jackson.KeyedTypeResolver;
 
 import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Objects;
 
-public abstract class CustomData {
+@JsonTypeResolver(KeyedTypeResolver.class)
+@JsonTypeIdResolver(KeyedTypeIdResolver.class)
+public abstract class CustomData implements Keyed {
 
     private final NamespacedKey namespacedKey;
 
@@ -53,6 +59,7 @@ public abstract class CustomData {
     /**
      * @return The namespacedKey, that is passed to this CustomData by it's {@link Provider}
      */
+    @Override
     public final NamespacedKey getNamespacedKey() {
         return namespacedKey;
     }
@@ -145,3 +152,4 @@ public abstract class CustomData {
 
     }
 }
+

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/CustomData.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/CustomData.java
@@ -1,5 +1,7 @@
 package me.wolfyscript.utilities.api.inventory.custom_items;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -18,8 +20,10 @@ import java.util.Objects;
 
 @JsonTypeResolver(KeyedTypeResolver.class)
 @JsonTypeIdResolver(KeyedTypeIdResolver.class)
+@JsonPropertyOrder("key")
 public abstract class CustomData implements Keyed {
 
+    @JsonProperty("key")
     private final NamespacedKey namespacedKey;
 
     /**

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/CustomItem.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/CustomItem.java
@@ -299,19 +299,37 @@ public class CustomItem extends AbstractItemBuilder<CustomItem> implements Keyed
         this.namespacedKey = namespacedKey;
     }
 
+    /**
+     * The replacement can be any of {@link APIReference} and it will replace this item when it is removed from the inventory using {@link #remove(ItemStack, int, Inventory, Location, boolean)}.
+     *
+     * @return True if this item has an replacement that is not AIR, else false.
+     */
     public boolean hasReplacement() {
         return replacement != null && !replacement.getLinkedItem().getType().equals(Material.AIR);
     }
 
+    /**
+     * The replacement can be any of {@link APIReference} and it will replace this item when it is removed from the inventory using {@link #remove(ItemStack, int, Inventory, Location, boolean)}.
+     *
+     * @return The {@link APIReference} of the custom replacement.
+     */
     @Nullable
     public APIReference getReplacement() {
         return hasReplacement() ? replacement : null;
     }
 
+    /**
+     * The replacement can be any of {@link APIReference} and it will replace this item when it is removed from the inventory using {@link #remove(ItemStack, int, Inventory, Location, boolean)}.
+     *
+     * @param replacement The replacement for this item.
+     */
     public void setReplacement(@Nullable APIReference replacement) {
         this.replacement = replacement;
     }
 
+    /**
+     * @return The durability that is removed from the item when removed from an inventory using {@link #remove(ItemStack, int, Inventory, Location, boolean)}
+     */
     public int getDurabilityCost() {
         return durabilityCost;
     }
@@ -320,6 +338,9 @@ public class CustomItem extends AbstractItemBuilder<CustomItem> implements Keyed
         this.durabilityCost = durabilityCost;
     }
 
+    /**
+     * @return True if the item is removed by calling {@link #remove(ItemStack, int, Inventory, Location, boolean)}.
+     */
     public boolean isConsumed() {
         return consumed;
     }
@@ -384,12 +405,27 @@ public class CustomItem extends AbstractItemBuilder<CustomItem> implements Keyed
         return equipmentSlots;
     }
 
+    /**
+     * @return True if the item has a custom {@link EquipmentSlot} it can be equipped to.
+     */
     public boolean hasEquipmentSlot() {
         return !getEquipmentSlots().isEmpty();
     }
 
     public boolean hasEquipmentSlot(EquipmentSlot slot) {
         return hasEquipmentSlot() && getEquipmentSlots().contains(slot);
+    }
+
+    public void addEquipmentSlots(EquipmentSlot... slots) {
+        for (EquipmentSlot slot : slots) {
+            if (!equipmentSlots.contains(slot)) {
+                equipmentSlots.add(slot);
+            }
+        }
+    }
+
+    public void removeEquipmentSlots(EquipmentSlot... slots) {
+        equipmentSlots.removeAll(Arrays.asList(slots));
     }
 
     /**
@@ -433,18 +469,6 @@ public class CustomItem extends AbstractItemBuilder<CustomItem> implements Keyed
 
     public void setBlockPlacement(boolean blockPlacement) {
         this.blockPlacement = blockPlacement;
-    }
-
-    public void addEquipmentSlots(EquipmentSlot... slots) {
-        for (EquipmentSlot slot : slots) {
-            if (!equipmentSlots.contains(slot)) {
-                equipmentSlots.add(slot);
-            }
-        }
-    }
-
-    public void removeEquipmentSlots(EquipmentSlot... slots) {
-        equipmentSlots.removeAll(Arrays.asList(slots));
     }
 
     public FuelSettings getFuelSettings() {
@@ -879,6 +903,10 @@ public class CustomItem extends AbstractItemBuilder<CustomItem> implements Keyed
         }
     }
 
+    /**
+     * @param input The input ItemStack, that is going to be edited.
+     * @deprecated Replaced by {@link #removeUnStackableItem(ItemStack)}
+     */
     @Deprecated
     public void consumeUnstackableItem(ItemStack input) {
         removeUnStackableItem(input);
@@ -901,6 +929,9 @@ public class CustomItem extends AbstractItemBuilder<CustomItem> implements Keyed
         return null;
     }
 
+    /**
+     * @return True if this item requires permission to be used, else false.
+     */
     public boolean hasPermission() {
         return !permission.isEmpty();
     }

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/CustomItem.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/CustomItem.java
@@ -64,7 +64,6 @@ public class CustomItem extends AbstractItemBuilder<CustomItem> implements Keyed
         return API_REFERENCE_PARSER.get(id);
     }
 
-
     @JsonIgnore
     private final Material type;
 
@@ -82,17 +81,6 @@ public class CustomItem extends AbstractItemBuilder<CustomItem> implements Keyed
         }
     }
 
-    @JsonIgnore
-    private final Material craftRemain;
-    @JsonAlias("api_reference")
-    private final APIReference apiReference;
-    @JsonAlias("custom_data")
-    @JsonDeserialize(using = CustomData.Deserializer.class)
-    @JsonSerialize(using = CustomData.Serializer.class)
-    private final Map<NamespacedKey, CustomData> customDataMap = new HashMap<>();
-    @JsonAlias("equipment_slots")
-    private final List<EquipmentSlot> equipmentSlots;
-    private boolean consumed;
     /**
      * This namespacedKey can either be null or non-null.
      * <p>
@@ -103,6 +91,18 @@ public class CustomItem extends AbstractItemBuilder<CustomItem> implements Keyed
      */
     @JsonIgnore
     private NamespacedKey namespacedKey;
+    @JsonIgnore
+    private final Material craftRemain;
+
+    @JsonAlias("api_reference")
+    private final APIReference apiReference;
+    @JsonAlias("custom_data")
+    @JsonDeserialize(using = CustomData.Deserializer.class)
+    @JsonSerialize(using = CustomData.Serializer.class)
+    private final Map<NamespacedKey, CustomData> customDataMap = new HashMap<>();
+    @JsonAlias("equipment_slots")
+    private final List<EquipmentSlot> equipmentSlots;
+    private boolean consumed;
     private boolean advanced;
     private boolean blockVanillaEquip;
     private boolean blockPlacement;
@@ -299,6 +299,7 @@ public class CustomItem extends AbstractItemBuilder<CustomItem> implements Keyed
         return namespacedKey != null;
     }
 
+    @Nullable
     @Override
     public NamespacedKey getNamespacedKey() {
         return namespacedKey;

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/CustomItem.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/CustomItem.java
@@ -345,7 +345,7 @@ public class CustomItem extends AbstractItemBuilder<CustomItem> implements Keyed
     }
 
     /**
-     * @return The allowed blocks this item can be used as fuel
+     * @return The blocks in which the item can be used as fuel
      * @deprecated Use {@link #getFuelSettings()} and {@link FuelSettings#getAllowedBlocks()}
      */
     @Deprecated
@@ -354,7 +354,7 @@ public class CustomItem extends AbstractItemBuilder<CustomItem> implements Keyed
     }
 
     /**
-     * @param allowedBlocks The allowed blocks this item can be used as fuel
+     * @param allowedBlocks The blocks in which the item can be used as fuel
      * @deprecated Use {@link #getFuelSettings()} and {@link FuelSettings#setAllowedBlocks(List)}
      */
     @Deprecated
@@ -362,6 +362,9 @@ public class CustomItem extends AbstractItemBuilder<CustomItem> implements Keyed
         fuelSettings.setAllowedBlocks(allowedBlocks);
     }
 
+    /**
+     * @return The EquipmentSlots this item can be equipped to.
+     */
     public List<EquipmentSlot> getEquipmentSlots() {
         return equipmentSlots;
     }
@@ -695,7 +698,7 @@ public class CustomItem extends AbstractItemBuilder<CustomItem> implements Keyed
     /**
      * Removes the input as an un-stackable item.
      * <p>
-     * Items that have replacements by default will be replaced with the according {@link Material} <br>
+     * Items that have craft remains by default will be replaced with the according {@link Material} <br>
      * Like Buckets, Potions, Stew/Soup.
      * </p>
      * <p>
@@ -706,8 +709,26 @@ public class CustomItem extends AbstractItemBuilder<CustomItem> implements Keyed
      * @param input The input ItemStack, that is going to be edited.
      */
     public void removeUnStackableItem(ItemStack input) {
+        removeUnStackableItem(input, true);
+    }
+
+    /**
+     * Removes the input as an un-stackable item.
+     * <p>
+     * Items that have craft remains by default will be replaced with the according {@link Material} <br>
+     * Like Buckets, Potions, Stew/Soup.
+     * </p>
+     * <p>
+     * If this CustomItem has a custom replacement then the input will be replaced with that.
+     * </p>
+     * <br>
+     *
+     * @param input              The input ItemStack, that is going to be edited.
+     * @param replaceWithRemains If the item should be replaced by it's remains if removed. Not including custom replacement options!
+     */
+    public void removeUnStackableItem(ItemStack input, boolean replaceWithRemains) {
         if (this.isConsumed()) {
-            if (craftRemain != null) {
+            if (craftRemain != null && replaceWithRemains) {
                 input.setType(craftRemain);
                 input.setItemMeta(Bukkit.getItemFactory().getItemMeta(craftRemain));
             } else {

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/CustomItem.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/CustomItem.java
@@ -1,6 +1,6 @@
 package me.wolfyscript.utilities.api.inventory.custom_items;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -54,28 +54,19 @@ import java.util.*;
  * These methods will include an extra {@link PersistentDataContainer} entry to identify the item later on!
  * </p>
  */
-@JsonSerialize(using = CustomItem.Serializer.class)
-@JsonDeserialize(using = CustomItem.Deserializer.class)
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE, isGetterVisibility = JsonAutoDetect.Visibility.NONE, setterVisibility = JsonAutoDetect.Visibility.NONE)
 public class CustomItem extends AbstractItemBuilder<CustomItem> implements Keyed {
 
     private static final Map<String, APIReference.Parser<?>> API_REFERENCE_PARSER = new HashMap<>();
-
-    private final Map<NamespacedKey, CustomData> customDataMap = new HashMap<>();
 
     @Nullable
     public static APIReference.Parser<?> getApiReferenceParser(String id) {
         return API_REFERENCE_PARSER.get(id);
     }
 
-    /**
-     * This namespacedKey can either be null or non-null.
-     * <p>
-     * If it's non-null, the item is saved and the variables of this Object will be persistent </p>
-     * when converted to ItemStack via {@link #create()}.
-     * <p>
-     * If it is null, the item isn't saved and the variables of this Object will get lost when {@link #create()} is called!
-     */
-    private NamespacedKey namespacedKey;
+
+    @JsonIgnore
+    private final Material type;
 
     /**
      * Register a new {@link APIReference.Parser} that can parse ItemStacks and keys from another plugin to a usable {@link APIReference}
@@ -91,32 +82,46 @@ public class CustomItem extends AbstractItemBuilder<CustomItem> implements Keyed
         }
     }
 
-    private final Material type;
+    @JsonIgnore
     private final Material craftRemain;
-    private boolean consumed;
-    private APIReference replacement;
-    private int durabilityCost;
-
-    private String permission;
-    private double rarityPercentage;
-    private FuelSettings fuelSettings;
-    private boolean blockPlacement;
-    private boolean blockVanillaEquip;
-    private boolean blockVanillaRecipes;
-    private final List<EquipmentSlot> equipmentSlots;
-    private boolean advanced;
-
-    /**
-     * Upcoming change to CustomItem will include an APIReference to link it
-     * to other external APIs.
-     *
-     * @see APIReference
-     */
+    @JsonAlias("api_reference")
     private final APIReference apiReference;
-    private ParticleContent particleContent;
+    @JsonAlias("custom_data")
+    @JsonDeserialize(using = CustomData.Deserializer.class)
+    @JsonSerialize(using = CustomData.Serializer.class)
+    private final Map<NamespacedKey, CustomData> customDataMap = new HashMap<>();
+    @JsonAlias("equipment_slots")
+    private final List<EquipmentSlot> equipmentSlots;
+    private boolean consumed;
+    /**
+     * This namespacedKey can either be null or non-null.
+     * <p>
+     * If it's non-null, the item is saved and the variables of this Object will be persistent </p>
+     * when converted to ItemStack via {@link #create()}.
+     * <p>
+     * If it is null, the item isn't saved and the variables of this Object will get lost when {@link #create()} is called!
+     */
+    @JsonIgnore
+    private NamespacedKey namespacedKey;
+    private boolean advanced;
+    private boolean blockVanillaEquip;
+    private boolean blockPlacement;
+    private boolean blockVanillaRecipes;
+    @JsonAlias("rarity_percentage")
+    private double rarityPercentage;
+    private String permission;
+    @JsonAlias("meta")
     private MetaSettings metaSettings;
+    private APIReference replacement;
+    @JsonAlias("fuel")
+    private FuelSettings fuelSettings;
+    @JsonAlias("durability_cost")
+    private int durabilityCost;
+    @JsonAlias("particles")
+    private ParticleContent particleContent;
 
-    public CustomItem(APIReference apiReference) {
+    @JsonCreator
+    public CustomItem(@JsonProperty("apiReference") @JsonAlias({"item", "api_reference"}) APIReference apiReference) {
         super(CustomItem.class);
         this.apiReference = apiReference;
 
@@ -346,6 +351,7 @@ public class CustomItem extends AbstractItemBuilder<CustomItem> implements Keyed
      * @deprecated Use {@link #getFuelSettings()} and {@link FuelSettings#getBurnTime()}
      */
     @Deprecated
+    @JsonIgnore
     public int getBurnTime() {
         return fuelSettings.getBurnTime();
     }
@@ -355,6 +361,7 @@ public class CustomItem extends AbstractItemBuilder<CustomItem> implements Keyed
      * @deprecated Use {@link #getFuelSettings()} and {@link FuelSettings#setBurnTime(int)}
      */
     @Deprecated
+    @JsonIgnore
     public void setBurnTime(int burnTime) {
         fuelSettings.setBurnTime(burnTime);
     }
@@ -364,6 +371,7 @@ public class CustomItem extends AbstractItemBuilder<CustomItem> implements Keyed
      * @deprecated Use {@link #getFuelSettings()} and {@link FuelSettings#getAllowedBlocks()}
      */
     @Deprecated
+    @JsonIgnore
     public List<Material> getAllowedBlocks() {
         return fuelSettings.getAllowedBlocks();
     }
@@ -373,6 +381,7 @@ public class CustomItem extends AbstractItemBuilder<CustomItem> implements Keyed
      * @deprecated Use {@link #getFuelSettings()} and {@link FuelSettings#setAllowedBlocks(List)}
      */
     @Deprecated
+    @JsonIgnore
     public void setAllowedBlocks(List<Material> allowedBlocks) {
         fuelSettings.setAllowedBlocks(allowedBlocks);
     }

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/FuelSettings.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/FuelSettings.java
@@ -1,16 +1,18 @@
 package me.wolfyscript.utilities.api.inventory.custom_items;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import org.bukkit.Material;
 
 import java.util.ArrayList;
 import java.util.List;
 
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 public class FuelSettings {
 
     @JsonAlias("allowed_blocks")
     private List<Material> allowedBlocks = new ArrayList<>();
-    @JsonAlias("burn_time")
+    @JsonAlias({"burn_time", "burntime"})
     private int burnTime = 20;
 
     public FuelSettings() {

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/FuelSettings.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/FuelSettings.java
@@ -1,0 +1,46 @@
+package me.wolfyscript.utilities.api.inventory.custom_items;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import org.bukkit.Material;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class FuelSettings {
+
+    @JsonAlias("allowed_blocks")
+    private List<Material> allowedBlocks = new ArrayList<>();
+    @JsonAlias("burn_time")
+    private int burnTime = 20;
+
+    public FuelSettings() {
+
+    }
+
+    public FuelSettings(FuelSettings settings) {
+        this.allowedBlocks = new ArrayList<>(settings.allowedBlocks);
+        this.burnTime = settings.burnTime;
+    }
+
+    public int getBurnTime() {
+        return burnTime;
+    }
+
+    public void setBurnTime(int burnTime) {
+        this.burnTime = burnTime;
+    }
+
+    public List<Material> getAllowedBlocks() {
+        return allowedBlocks;
+    }
+
+    public void setAllowedBlocks(List<Material> allowedBlocks) {
+        this.allowedBlocks = allowedBlocks;
+    }
+
+    @Override
+    public FuelSettings clone() {
+        return new FuelSettings(this);
+    }
+
+}

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/references/APIReference.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/references/APIReference.java
@@ -8,11 +8,27 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
+/**
+ * This object is a wrapper for items that are part of external APIs or vanilla minecraft. <br>
+ * It makes it possible to reference and manage items from possibly multiple plugins at the same time.
+ *
+ * <p>
+ * There are following references available:
+ * <ul>
+ *     <li>{@link VanillaRef}</li>
+ *     <li>{@link WolfyUtilitiesRef}</li>
+ *     <li>{@link OraxenRef}</li>
+ *     <li>{@link ItemsAdderRef}</li>
+ *     <li>{@link MMOItemsRef}</li>
+ *     <li>{@link MythicMobsRef}</li>
+ * </ul>
+ * </p>
+ * <p>
+ * You can register additional references inside your plugin (onEnable) using {@link me.wolfyscript.utilities.api.inventory.custom_items.CustomItem#registerAPIReferenceParser(Parser)}.
+ */
 public abstract class APIReference {
 
     protected int amount;
@@ -31,10 +47,12 @@ public abstract class APIReference {
     public abstract ItemStack getLinkedItem();
 
     /**
-     * Use this method inside of GUIs that you need to handle APIs that don't save NamespacedKeys inside the ItemStack PersistentData!
+     * Use this method inside of GUIs that you need, to handle APIs that don't save NamespacedKeys inside the ItemStack PersistentData!
      *
      * @return a ItemStack of the API with additional PersistentDataHolder that contains the NamespacedKey or other value of the API
+     * @deprecated This method should not be used! It usually returns the same as {@link #getLinkedItem()}!
      */
+    @Deprecated
     public abstract ItemStack getIdItem();
 
     public abstract boolean isValidItem(ItemStack itemStack);
@@ -93,22 +111,22 @@ public abstract class APIReference {
         private final String id;
         private final List<String> aliases;
 
-        public Parser(String id) {
+        protected Parser(String id) {
             this(id, 0);
         }
 
-        public Parser(String id, int priority) {
+        protected Parser(String id, int priority) {
             this(id, priority, new String[0]);
         }
 
-        public Parser(String id, String... aliases) {
+        protected Parser(String id, String... aliases) {
             this(id, 0, aliases);
         }
 
-        public Parser(String id, int priority, String... aliases) {
+        protected Parser(String id, int priority, String... aliases) {
             this.id = id;
             this.priority = priority;
-            this.aliases = Collections.unmodifiableList(Arrays.asList(aliases));
+            this.aliases = List.of(aliases);
         }
 
         public String getId() {
@@ -136,7 +154,7 @@ public abstract class APIReference {
 
         private final String pluginName;
 
-        public PluginParser(String pluginName, String id, String... aliases) {
+        protected PluginParser(String pluginName, String id, String... aliases) {
             super(id, aliases);
             this.pluginName = pluginName;
         }

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/references/ItemsAdderRef.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/references/ItemsAdderRef.java
@@ -11,6 +11,11 @@ import org.jetbrains.annotations.Nullable;
 import java.io.IOException;
 import java.util.Objects;
 
+/**
+ * Links to an ItemsAdder item and saves the item key accordingly.
+ * <br>
+ * It will always get the latest item version available in ItemsAdder or AIR if not available.
+ */
 public class ItemsAdderRef extends APIReference {
 
     private final String itemID;
@@ -25,9 +30,12 @@ public class ItemsAdderRef extends APIReference {
         this.itemID = itemsAdderRef.itemID;
     }
 
+    /**
+     * @return The latest ItemStack available in ItemsAdder under the specified itemID or AIR.
+     */
     @Override
     public ItemStack getLinkedItem() {
-        CustomStack customStack = CustomStack.getInstance(itemID);
+        var customStack = CustomStack.getInstance(itemID);
         if (customStack != null) {
             return customStack.getItemStack();
         }
@@ -41,7 +49,7 @@ public class ItemsAdderRef extends APIReference {
 
     @Override
     public boolean isValidItem(ItemStack itemStack) {
-        CustomStack customStack = CustomStack.byItemStack(itemStack);
+        var customStack = CustomStack.byItemStack(itemStack);
         return customStack != null && Objects.equals(itemID, customStack.getNamespacedID());
     }
 
@@ -80,7 +88,7 @@ public class ItemsAdderRef extends APIReference {
 
         @Override
         public @Nullable ItemsAdderRef construct(ItemStack itemStack) {
-            CustomStack customStack = CustomStack.byItemStack(itemStack);
+            var customStack = CustomStack.byItemStack(itemStack);
             if (customStack != null) {
                 return new ItemsAdderRef(customStack.getNamespacedID());
             }

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/references/MMOItemsRef.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/references/MMOItemsRef.java
@@ -12,6 +12,9 @@ import org.jetbrains.annotations.Nullable;
 import java.io.IOException;
 import java.util.Objects;
 
+/**
+ * Links to MMOItems and saves the specified {@link Type} and Name of the item.
+ */
 public class MMOItemsRef extends APIReference {
 
     private final Type itemType;
@@ -41,7 +44,7 @@ public class MMOItemsRef extends APIReference {
 
     @Override
     public boolean isValidItem(ItemStack itemStack) {
-        NBTItem nbtItem = NBTItem.get(itemStack);
+        var nbtItem = NBTItem.get(itemStack);
         if (nbtItem.hasType()) {
             return Objects.equals(this.itemType, MMOItems.plugin.getTypes().get(nbtItem.getType())) && Objects.equals(this.itemName, nbtItem.getString("MMOITEMS_ITEM_ID"));
         }

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/references/MythicMobsRef.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/references/MythicMobsRef.java
@@ -13,6 +13,15 @@ import org.jetbrains.annotations.Nullable;
 import java.io.IOException;
 import java.util.Objects;
 
+/**
+ * Links to MythicMobs items and saves the specified item type.
+ * <p>
+ * For items to be detected by plugins in-game you need to add an additional Option to your MythicMobs item!
+ * <pre>
+ * Options:
+ *     AppendType: true
+ * </pre>
+ */
 public class MythicMobsRef extends APIReference {
 
     private static final String ITEM_KEY = "MYTHIC_TYPE";

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/references/OraxenRef.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/references/OraxenRef.java
@@ -11,6 +11,9 @@ import org.jetbrains.annotations.Nullable;
 import java.io.IOException;
 import java.util.Objects;
 
+/**
+ * Links to Oraxen and saves the specified id of the item.
+ */
 public class OraxenRef extends APIReference {
 
     private final String itemID;

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/references/VanillaRef.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/references/VanillaRef.java
@@ -11,6 +11,9 @@ import org.jetbrains.annotations.Nullable;
 import java.io.IOException;
 import java.util.Objects;
 
+/**
+ * Links to and saves a vanilla Bukkit ItemStack.
+ */
 public class VanillaRef extends APIReference {
 
     private final ItemStack itemStack;
@@ -77,7 +80,7 @@ public class VanillaRef extends APIReference {
 
         @Override
         public @Nullable APIReference parse(JsonNode element) {
-            ItemStack itemStack = JacksonUtil.getObjectMapper().convertValue(element, ItemStack.class);
+            var itemStack = JacksonUtil.getObjectMapper().convertValue(element, ItemStack.class);
             if (itemStack != null) {
                 APIReference.Parser<?> parser = CustomItem.getApiReferenceParser("wolfyutilities");
                 if (parser != null) {

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/references/WolfyUtilitiesRef.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/references/WolfyUtilitiesRef.java
@@ -4,18 +4,19 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import me.wolfyscript.utilities.api.WolfyUtilities;
-import me.wolfyscript.utilities.api.inventory.custom_items.CustomItem;
 import me.wolfyscript.utilities.util.NamespacedKey;
 import me.wolfyscript.utilities.util.Registry;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.persistence.PersistentDataType;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
 import java.util.Objects;
 
+/**
+ * Links to items of WolfyUtilities and saves the specified {@link NamespacedKey}
+ */
 public class WolfyUtilitiesRef extends APIReference {
 
     private static final org.bukkit.NamespacedKey CUSTOM_ITEM_KEY = new org.bukkit.NamespacedKey(WolfyUtilities.getWUPlugin(), "custom_item");
@@ -37,7 +38,7 @@ public class WolfyUtilitiesRef extends APIReference {
 
     @Override
     public ItemStack getLinkedItem() {
-        CustomItem customItem = Registry.CUSTOM_ITEMS.get(namespacedKey);
+        var customItem = Registry.CUSTOM_ITEMS.get(namespacedKey);
         if (customItem != null) {
             return customItem.create();
         }
@@ -47,14 +48,14 @@ public class WolfyUtilitiesRef extends APIReference {
 
     @Override
     public ItemStack getIdItem() {
-        ItemStack itemStack = getLinkedItem();
+        var itemStack = getLinkedItem();
         return itemStack == null ? new ItemStack(Material.AIR) : itemStack;
     }
 
     @Override
     public boolean isValidItem(ItemStack itemStack) {
         if (itemStack != null) {
-            ItemMeta itemMeta = itemStack.getItemMeta();
+            var itemMeta = itemStack.getItemMeta();
             if (itemMeta != null) {
                 var container = itemMeta.getPersistentDataContainer();
                 if (container.has(CUSTOM_ITEM_KEY, PersistentDataType.STRING)) {

--- a/core/src/main/java/me/wolfyscript/utilities/util/inventory/item_builder/AbstractItemBuilder.java
+++ b/core/src/main/java/me/wolfyscript/utilities/util/inventory/item_builder/AbstractItemBuilder.java
@@ -1,5 +1,7 @@
 package me.wolfyscript.utilities.util.inventory.item_builder;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.mojang.authlib.GameProfile;
 import com.mojang.authlib.properties.Property;
 import me.wolfyscript.utilities.util.EncryptionUtils;
@@ -22,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+@JsonAutoDetect(getterVisibility = JsonAutoDetect.Visibility.NONE, setterVisibility = JsonAutoDetect.Visibility.NONE, isGetterVisibility = JsonAutoDetect.Visibility.NONE)
 public abstract class AbstractItemBuilder<T extends AbstractItemBuilder<?>> {
 
     private static final NamespacedKey CUSTOM_DURABILITY_VALUE = new NamespacedKey("wolfyutilities", "custom_durability.value");
@@ -29,6 +32,7 @@ public abstract class AbstractItemBuilder<T extends AbstractItemBuilder<?>> {
     private static final NamespacedKey CUSTOM_DURABILITY_INDEX = new NamespacedKey("wolfyutilities", "custom_durability.index");
     private static final NamespacedKey CUSTOM_DURABILITY_TAG = new NamespacedKey("wolfyutilities", "custom_durability.tag");
 
+    @JsonIgnore
     private final Class<T> typeClass;
 
     protected AbstractItemBuilder(Class<T> typeClass) {
@@ -52,6 +56,7 @@ public abstract class AbstractItemBuilder<T extends AbstractItemBuilder<?>> {
         return get();
     }
 
+    @JsonIgnore
     public ItemMeta getItemMeta() {
         return getItemStack().getItemMeta();
     }

--- a/wolfyutilities/src/main/java/me/wolfyscript/utilities/main/WUPlugin.java
+++ b/wolfyutilities/src/main/java/me/wolfyscript/utilities/main/WUPlugin.java
@@ -117,6 +117,8 @@ public class WUPlugin extends JavaPlugin {
         meta.register(NamespacedKey.wolfyutilties("potion"), PotionMeta.class);
         meta.register(NamespacedKey.wolfyutilties("repair_cost"), RepairCostMeta.class);
         meta.register(NamespacedKey.wolfyutilties("unbreakable"), UnbreakableMeta.class);
+
+        //KeyedTypeIdResolver.registerTypeRegistry(CustomData.class, Registry.CUSTOM_ITEM_DATA);
     }
 
     @Override


### PR DESCRIPTION
This removes the custom serializer/deserializer for the CustomItem to make it easier to structure and keep it object orientated.
Kept functionallity of the CustomData by adding a custom serializer for it. (CustomData is most likely to be replaced in the future and the serializer is only for backwards compatibility)

This update also restructures the CustomItem especially the "consume" methods have been renamed to "remove", so it isn't confused with food consumption.