### PR TITLE
Improved the CustomItem meta checks

### DIFF
--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/CustomItem.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/CustomItem.java
@@ -145,7 +145,7 @@ public class CustomItem extends AbstractItemBuilder<CustomItem> implements Keyed
 
         this.namespacedKey = null;
         this.fuelSettings = new FuelSettings();
-        this.nbtChecks = new MetaSettings();
+        setMetaSettings(new MetaSettings());
         this.permission = "";
         this.rarityPercentage = apiReference.getWeight() > 0 ? apiReference.getWeight() : 1.0d;
         for (CustomData.Provider<?> customData : Registry.CUSTOM_ITEM_DATA.values()) {

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/CustomItem.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/CustomItem.java
@@ -595,9 +595,7 @@ public class CustomItem extends AbstractItemBuilder<CustomItem> implements Keyed
     public boolean isSimilar(ItemStack otherItem, boolean exactMeta, boolean ignoreAmount) {
         if (otherItem != null && otherItem.getType().equals(this.type) && (ignoreAmount || otherItem.getAmount() >= getAmount())) {
             if (hasNamespacedKey()) {
-                var customItem = new ItemBuilder(getItemStack());
-                var customItemOther = new ItemBuilder(otherItem);
-                return getMetaSettings().check(customItemOther, customItem);
+                return getMetaSettings().check(this, new ItemBuilder(otherItem));
             }
             return (!(getApiReference() instanceof VanillaRef) || (exactMeta || hasItemMeta())) && getApiReference().isValidItem(otherItem);
         }

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/CustomItem.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/CustomItem.java
@@ -554,17 +554,17 @@ public class CustomItem extends AbstractItemBuilder<CustomItem> implements Keyed
         if (otherItem != null && otherItem.getType().equals(this.type) && (ignoreAmount || otherItem.getAmount() >= getAmount())) {
             if (hasNamespacedKey()) {
                 var other = CustomItem.getByItemStack(otherItem);
-                if (ItemUtils.isAirOrNull(other) || !other.hasNamespacedKey() || !getNamespacedKey().equals(other.getNamespacedKey())) {
+                if (ItemUtils.isAirOrNull(other) || !Objects.equals(getNamespacedKey(), other.getNamespacedKey())) {
                     return false;
                 }
-            } else if (!getApiReference().isValidItem(otherItem)) {
-                return false;
-            }
-            if ((exactMeta || hasItemMeta()) && (isAdvanced() || (getApiReference() instanceof VanillaRef && !hasNamespacedKey()))) {
-                var customItem = new ItemBuilder(getItemStack().clone());
-                var customItemOther = new ItemBuilder(otherItem.clone());
-                return getMetaSettings().check(customItemOther, customItem) && Bukkit.getItemFactory().equals(customItem.getItemMeta(), customItemOther.getItemMeta());
-            }
+                if (isAdvanced()) {
+                    var customItem = new ItemBuilder(getItemStack());
+                    var customItemOther = new ItemBuilder(otherItem);
+                    return getMetaSettings().check(customItemOther, customItem);
+                }
+            } else if(getApiReference() instanceof VanillaRef) {
+                return (exactMeta || hasItemMeta()) && getApiReference().isValidItem(otherItem);
+            } else return getApiReference().isValidItem(otherItem);
             return true;
         }
         return false;

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/CustomItem.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/CustomItem.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.Streams;
 import me.wolfyscript.utilities.api.WolfyUtilities;
+import me.wolfyscript.utilities.api.inventory.custom_items.meta.CustomItemTagMeta;
 import me.wolfyscript.utilities.api.inventory.custom_items.meta.MetaSettings;
 import me.wolfyscript.utilities.api.inventory.custom_items.references.APIReference;
 import me.wolfyscript.utilities.api.inventory.custom_items.references.VanillaRef;
@@ -48,6 +49,7 @@ import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.Damageable;
+import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
 import org.jetbrains.annotations.NotNull;
@@ -72,6 +74,8 @@ import java.util.stream.Stream;
  */
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE, isGetterVisibility = JsonAutoDetect.Visibility.NONE, setterVisibility = JsonAutoDetect.Visibility.NONE)
 public class CustomItem extends AbstractItemBuilder<CustomItem> implements Keyed {
+
+    public static final org.bukkit.NamespacedKey PERSISTENT_KEY_TAG = new org.bukkit.NamespacedKey(WolfyUtilities.getWUPlugin(), "custom_item");
 
     private static final Map<String, APIReference.Parser<?>> API_REFERENCE_PARSER = new HashMap<>();
 
@@ -568,17 +572,11 @@ public class CustomItem extends AbstractItemBuilder<CustomItem> implements Keyed
     public boolean isSimilar(ItemStack otherItem, boolean exactMeta, boolean ignoreAmount) {
         if (otherItem != null && otherItem.getType().equals(this.type) && (ignoreAmount || otherItem.getAmount() >= getAmount())) {
             if (hasNamespacedKey()) {
-                var other = CustomItem.getByItemStack(otherItem);
-                if (ItemUtils.isAirOrNull(other) || !Objects.equals(getNamespacedKey(), other.getNamespacedKey())) {
-                    return false;
-                }
-                if (isAdvanced()) {
-                    var customItem = new ItemBuilder(getItemStack());
-                    var customItemOther = new ItemBuilder(otherItem);
-                    return getMetaSettings().check(customItemOther, customItem);
-                }
-            } else return (!(getApiReference() instanceof VanillaRef) || (exactMeta || hasItemMeta())) && getApiReference().isValidItem(otherItem);
-            return true;
+                var customItem = new ItemBuilder(getItemStack());
+                var customItemOther = new ItemBuilder(otherItem);
+                return getMetaSettings().check(customItemOther, customItem);
+            }
+            return (!(getApiReference() instanceof VanillaRef) || (exactMeta || hasItemMeta())) && getApiReference().isValidItem(otherItem);
         }
         return false;
     }

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/CustomItem.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/CustomItem.java
@@ -114,6 +114,10 @@ public class CustomItem extends AbstractItemBuilder<CustomItem> implements Keyed
     @JsonIgnore
     private final Material craftRemain;
 
+    @JsonIgnore
+    @Deprecated
+    private boolean advanced;
+
     @JsonAlias("api_reference")
     private final APIReference apiReference;
     @JsonAlias("custom_data")
@@ -123,7 +127,6 @@ public class CustomItem extends AbstractItemBuilder<CustomItem> implements Keyed
     @JsonAlias("equipment_slots")
     private final List<EquipmentSlot> equipmentSlots;
     private boolean consumed;
-    private boolean advanced;
     private boolean blockVanillaEquip;
     private boolean blockPlacement;
     private boolean blockVanillaRecipes;

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/CustomItem.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/CustomItem.java
@@ -562,9 +562,7 @@ public class CustomItem extends AbstractItemBuilder<CustomItem> implements Keyed
                     var customItemOther = new ItemBuilder(otherItem);
                     return getMetaSettings().check(customItemOther, customItem);
                 }
-            } else if(getApiReference() instanceof VanillaRef) {
-                return (exactMeta || hasItemMeta()) && getApiReference().isValidItem(otherItem);
-            } else return getApiReference().isValidItem(otherItem);
+            } else return (!(getApiReference() instanceof VanillaRef) || (exactMeta || hasItemMeta())) && getApiReference().isValidItem(otherItem);
             return true;
         }
         return false;

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/CustomItem.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/CustomItem.java
@@ -389,7 +389,14 @@ public class CustomItem extends AbstractItemBuilder<CustomItem> implements Keyed
 
     public void setMetaSettings(MetaSettings metaSettings) {
         this.metaSettings = metaSettings;
-        this.advanced = !metaSettings.getChecks().isEmpty();
+        if (!advanced) { //If advanced is disabled the MetaSettings are not used, so we clear them!
+            advanced = true;
+            metaSettings.clearChecks();
+        }
+        if (metaSettings.isEmpty()) {
+            //Add the CustomItemTag check, so the item will be checked correctly, but only if the item hasn't got any other checks already.
+            metaSettings.addCheck(new CustomItemTagMeta());
+        }
     }
 
     /**

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/CustomItem.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/CustomItem.java
@@ -76,16 +76,12 @@ import java.util.stream.Stream;
 public class CustomItem extends AbstractItemBuilder<CustomItem> implements Keyed {
 
     public static final org.bukkit.NamespacedKey PERSISTENT_KEY_TAG = new org.bukkit.NamespacedKey(WolfyUtilities.getWUPlugin(), "custom_item");
-
     private static final Map<String, APIReference.Parser<?>> API_REFERENCE_PARSER = new HashMap<>();
 
     @Nullable
     public static APIReference.Parser<?> getApiReferenceParser(String id) {
         return API_REFERENCE_PARSER.get(id);
     }
-
-    @JsonIgnore
-    private final Material type;
 
     /**
      * Register a new {@link APIReference.Parser} that can parse ItemStacks and keys from another plugin to a usable {@link APIReference}
@@ -100,6 +96,9 @@ public class CustomItem extends AbstractItemBuilder<CustomItem> implements Keyed
             }
         }
     }
+
+    @JsonIgnore
+    private final Material type;
 
     /**
      * This namespacedKey can either be null or non-null.

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/CustomItem.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/CustomItem.java
@@ -301,12 +301,20 @@ public class CustomItem extends AbstractItemBuilder<CustomItem> implements Keyed
         if (itemStack != null) {
             var itemMeta = itemStack.getItemMeta();
             if (itemMeta != null) {
-                var container = itemMeta.getPersistentDataContainer();
-                var namespacedKey = new org.bukkit.NamespacedKey(WolfyUtilities.getWUPlugin(), "custom_item");
-                if (container.has(namespacedKey, PersistentDataType.STRING)) {
-                    return Registry.CUSTOM_ITEMS.get(NamespacedKey.of(container.get(namespacedKey, PersistentDataType.STRING)));
-                }
+                return Registry.CUSTOM_ITEMS.get(getKeyOfItemMeta(itemMeta));
             }
+        }
+        return null;
+    }
+
+    /**
+     * @param itemMeta The ItemMeta to get the key from.
+     * @return The CustomItems {@link NamespacedKey} from the ItemMeta; or null if the ItemMeta doesn't contain a key.
+     */
+    public static NamespacedKey getKeyOfItemMeta(ItemMeta itemMeta) {
+        var container = itemMeta.getPersistentDataContainer();
+        if (container.has(PERSISTENT_KEY_TAG, PersistentDataType.STRING)) {
+            return NamespacedKey.of(container.get(PERSISTENT_KEY_TAG, PersistentDataType.STRING));
         }
         return null;
     }

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/CustomItem.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/CustomItem.java
@@ -164,6 +164,37 @@ public class CustomItem extends AbstractItemBuilder<CustomItem> implements Keyed
         this.craftRemain = getCraftRemain();
     }
 
+    @JsonAnySetter
+    protected void setOldProperties(String fieldKey, JsonNode value) throws JsonProcessingException {
+        if (fieldKey.equals("metaSettings") || fieldKey.equals("meta")) {
+            //Since the new system has its new field we need to update old appearances to the new system.
+            JsonNode node = value.isTextual() ? JacksonUtil.getObjectMapper().readTree(value.asText()) : value;
+            final List<Meta> checks;
+            if (!node.has(MetaSettings.CHECKS_KEY)) {
+                checks = new ArrayList<>();
+                //Convert old meta to new format.
+                node.fields().forEachRemaining(entry -> {
+                    if (entry.getValue() instanceof ObjectNode entryVal) {
+                        String key = entry.getKey().toLowerCase(Locale.ROOT);
+                        NamespacedKey namespacedKey = key.contains(":") ? NamespacedKey.of(key) : NamespacedKey.wolfyutilties(key);
+                        if (namespacedKey != null) {
+                            entryVal.put("key", String.valueOf(namespacedKey));
+                            Meta meta = JacksonUtil.getObjectMapper().convertValue(entryVal, Meta.class);
+                            if (meta != null && !meta.getOption().equals(MetaSettings.Option.IGNORE)) {
+                                checks.add(meta);
+                            }
+                        }
+                    }
+                });
+            } else {
+                checks = JacksonUtil.getObjectMapper().convertValue(node.get(MetaSettings.CHECKS_KEY), new TypeReference<>() {});
+            }
+            var nbtChecks = new MetaSettings();
+            checks.forEach(nbtChecks::addCheck);
+            this.nbtChecks = nbtChecks;
+        }
+    }
+
     /**
      * Creates a CustomItem with a Vanilla Reference to the itemstack
      *

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/CustomItem.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/CustomItem.java
@@ -381,7 +381,7 @@ public class CustomItem extends AbstractItemBuilder<CustomItem> implements Keyed
 
     public void setMetaSettings(MetaSettings metaSettings) {
         this.metaSettings = metaSettings;
-        this.advanced = metaSettings.values().parallelStream().anyMatch(meta -> !meta.getOption().equals(MetaSettings.Option.EXACT) && !meta.getOption().equals(MetaSettings.Option.IGNORE));
+        this.advanced = !metaSettings.getChecks().isEmpty();
     }
 
     /**

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/CustomItem.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/CustomItem.java
@@ -596,8 +596,10 @@ public class CustomItem extends AbstractItemBuilder<CustomItem> implements Keyed
         if (otherItem != null && otherItem.getType().equals(this.type) && (ignoreAmount || otherItem.getAmount() >= getAmount())) {
             if (hasNamespacedKey()) {
                 return getMetaSettings().check(this, new ItemBuilder(otherItem));
+            } else if (getApiReference() instanceof VanillaRef && (!hasItemMeta() && !exactMeta)) {
+                return true;
             }
-            return (!(getApiReference() instanceof VanillaRef) || (exactMeta || hasItemMeta())) && getApiReference().isValidItem(otherItem);
+            return getApiReference().isValidItem(otherItem);
         }
         return false;
     }

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/AttributesModifiersMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/AttributesModifiersMeta.java
@@ -32,22 +32,21 @@ public class AttributesModifiersMeta extends Meta {
         setAvailableOptions(MetaSettings.Option.EXACT, MetaSettings.Option.IGNORE);
     }
 
+    private static boolean compareModifiers(Multimap<Attribute, AttributeModifier> first, Multimap<Attribute, AttributeModifier> second) {
+        if (first != null && second != null) {
+            return first.entries().stream().allMatch(entry -> second.containsEntry(entry.getKey(), entry.getValue())) && second.entries().stream().allMatch(entry -> first.containsEntry(entry.getKey(), entry.getValue()));
+        } else {
+            return false;
+        }
+    }
+
     @Override
     public boolean check(ItemBuilder itemOther, ItemBuilder item) {
         ItemMeta metaOther = itemOther.getItemMeta();
         ItemMeta meta = item.getItemMeta();
-        if (option.equals(MetaSettings.Option.IGNORE)) {
-            if (metaOther.hasAttributeModifiers()) {
-                Multimap<Attribute, AttributeModifier> modifiers = metaOther.getAttributeModifiers();
-                modifiers.keySet().forEach(metaOther::removeAttributeModifier);
-            }
-            if (meta.hasAttributeModifiers()) {
-                Multimap<Attribute, AttributeModifier> modifiers = metaOther.getAttributeModifiers();
-                modifiers.keySet().forEach(metaOther::removeAttributeModifier);
-            }
+        if (meta.hasAttributeModifiers()) {
+            return metaOther.hasAttributeModifiers() && compareModifiers(meta.getAttributeModifiers(), metaOther.getAttributeModifiers());
         }
-        itemOther.setItemMeta(metaOther);
-        item.setItemMeta(meta);
-        return true;
+        return !metaOther.hasAttributeModifiers();
     }
 }

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/AttributesModifiersMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/AttributesModifiersMeta.java
@@ -29,7 +29,7 @@ public class AttributesModifiersMeta extends Meta {
 
     public AttributesModifiersMeta() {
         setOption(MetaSettings.Option.EXACT);
-        setAvailableOptions(MetaSettings.Option.EXACT, MetaSettings.Option.IGNORE);
+        setAvailableOptions(MetaSettings.Option.EXACT);
     }
 
     private static boolean compareModifiers(Multimap<Attribute, AttributeModifier> first, Multimap<Attribute, AttributeModifier> second) {

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/AttributesModifiersMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/AttributesModifiersMeta.java
@@ -20,12 +20,15 @@ package me.wolfyscript.utilities.api.inventory.custom_items.meta;
 
 
 import com.google.common.collect.Multimap;
+import me.wolfyscript.utilities.util.NamespacedKey;
 import me.wolfyscript.utilities.util.inventory.item_builder.ItemBuilder;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeModifier;
 import org.bukkit.inventory.meta.ItemMeta;
 
 public class AttributesModifiersMeta extends Meta {
+
+    public static final NamespacedKey KEY = NamespacedKey.wolfyutilties("attributes_modifiers");
 
     public AttributesModifiersMeta() {
         setOption(MetaSettings.Option.EXACT);

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/AttributesModifiersMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/AttributesModifiersMeta.java
@@ -31,6 +31,7 @@ public class AttributesModifiersMeta extends Meta {
     public static final NamespacedKey KEY = NamespacedKey.wolfyutilties("attributes_modifiers");
 
     public AttributesModifiersMeta() {
+        super(KEY);
         setOption(MetaSettings.Option.EXACT);
         setAvailableOptions(MetaSettings.Option.EXACT);
     }

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/AttributesModifiersMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/AttributesModifiersMeta.java
@@ -20,6 +20,7 @@ package me.wolfyscript.utilities.api.inventory.custom_items.meta;
 
 
 import com.google.common.collect.Multimap;
+import me.wolfyscript.utilities.api.inventory.custom_items.CustomItem;
 import me.wolfyscript.utilities.util.NamespacedKey;
 import me.wolfyscript.utilities.util.inventory.item_builder.ItemBuilder;
 import org.bukkit.attribute.Attribute;
@@ -32,8 +33,6 @@ public class AttributesModifiersMeta extends Meta {
 
     public AttributesModifiersMeta() {
         super(KEY);
-        setOption(MetaSettings.Option.EXACT);
-        setAvailableOptions(MetaSettings.Option.EXACT);
     }
 
     private static boolean compareModifiers(Multimap<Attribute, AttributeModifier> first, Multimap<Attribute, AttributeModifier> second) {
@@ -45,7 +44,7 @@ public class AttributesModifiersMeta extends Meta {
     }
 
     @Override
-    public boolean check(ItemBuilder itemOther, ItemBuilder item) {
+    public boolean check(CustomItem item, ItemBuilder itemOther) {
         ItemMeta metaOther = itemOther.getItemMeta();
         ItemMeta meta = item.getItemMeta();
         if (meta.hasAttributeModifiers()) {

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/CustomDamageMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/CustomDamageMeta.java
@@ -33,27 +33,13 @@ public class CustomDamageMeta extends Meta {
     public boolean check(ItemBuilder itemOther, ItemBuilder item) {
         boolean meta0 = item.hasCustomDurability();
         boolean meta1 = itemOther.hasCustomDurability();
-        ItemMeta metaOther = itemOther.getItemMeta();
-        ItemMeta meta = item.getItemMeta();
         if (meta0 && meta1) {
-            switch (option) {
-                case EXACT:
-                    return itemOther.getCustomDamage() == item.getCustomDamage();
-                case IGNORE:
-                    itemOther.setCustomDamage(0);
-                    item.setCustomDamage(0);
-                    ((Damageable) metaOther).setDamage(0);
-                    ((Damageable) meta).setDamage(0);
-                    itemOther.setItemMeta(metaOther);
-                    item.setItemMeta(meta);
-                    return true;
-                case LOWER:
-                    return itemOther.getCustomDamage() < item.getCustomDamage();
-                case HIGHER:
-                    return itemOther.getCustomDamage() > item.getCustomDamage();
-                default:
-                    return true;
-            }
+            return switch (option) {
+                case EXACT -> itemOther.getCustomDamage() == item.getCustomDamage();
+                case LOWER -> itemOther.getCustomDamage() < item.getCustomDamage();
+                case HIGHER -> itemOther.getCustomDamage() > item.getCustomDamage();
+                default -> false;
+            };
         } else return !meta0 && !meta1;
     }
 }

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/CustomDamageMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/CustomDamageMeta.java
@@ -18,6 +18,7 @@
 
 package me.wolfyscript.utilities.api.inventory.custom_items.meta;
 
+import me.wolfyscript.utilities.api.inventory.custom_items.CustomItem;
 import me.wolfyscript.utilities.util.NamespacedKey;
 import me.wolfyscript.utilities.util.inventory.item_builder.ItemBuilder;
 import org.bukkit.inventory.meta.Damageable;
@@ -29,12 +30,11 @@ public class CustomDamageMeta extends Meta {
 
     public CustomDamageMeta() {
         super(KEY);
-        setOption(MetaSettings.Option.EXACT);
         setAvailableOptions(MetaSettings.Option.EXACT, MetaSettings.Option.HIGHER, MetaSettings.Option.LOWER);
     }
 
     @Override
-    public boolean check(ItemBuilder itemOther, ItemBuilder item) {
+    public boolean check(CustomItem item, ItemBuilder itemOther) {
         boolean meta0 = item.hasCustomDurability();
         boolean meta1 = itemOther.hasCustomDurability();
         if (meta0 && meta1) {

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/CustomDamageMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/CustomDamageMeta.java
@@ -26,7 +26,7 @@ public class CustomDamageMeta extends Meta {
 
     public CustomDamageMeta() {
         setOption(MetaSettings.Option.EXACT);
-        setAvailableOptions(MetaSettings.Option.EXACT, MetaSettings.Option.IGNORE, MetaSettings.Option.HIGHER, MetaSettings.Option.LOWER);
+        setAvailableOptions(MetaSettings.Option.EXACT, MetaSettings.Option.HIGHER, MetaSettings.Option.LOWER);
     }
 
     @Override

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/CustomDamageMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/CustomDamageMeta.java
@@ -18,11 +18,14 @@
 
 package me.wolfyscript.utilities.api.inventory.custom_items.meta;
 
+import me.wolfyscript.utilities.util.NamespacedKey;
 import me.wolfyscript.utilities.util.inventory.item_builder.ItemBuilder;
 import org.bukkit.inventory.meta.Damageable;
 import org.bukkit.inventory.meta.ItemMeta;
 
 public class CustomDamageMeta extends Meta {
+
+    public static final NamespacedKey KEY = NamespacedKey.wolfyutilties("custom_damage");
 
     public CustomDamageMeta() {
         setOption(MetaSettings.Option.EXACT);

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/CustomDamageMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/CustomDamageMeta.java
@@ -21,8 +21,6 @@ package me.wolfyscript.utilities.api.inventory.custom_items.meta;
 import me.wolfyscript.utilities.api.inventory.custom_items.CustomItem;
 import me.wolfyscript.utilities.util.NamespacedKey;
 import me.wolfyscript.utilities.util.inventory.item_builder.ItemBuilder;
-import org.bukkit.inventory.meta.Damageable;
-import org.bukkit.inventory.meta.ItemMeta;
 
 public class CustomDamageMeta extends Meta {
 

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/CustomDamageMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/CustomDamageMeta.java
@@ -28,6 +28,7 @@ public class CustomDamageMeta extends Meta {
     public static final NamespacedKey KEY = NamespacedKey.wolfyutilties("custom_damage");
 
     public CustomDamageMeta() {
+        super(KEY);
         setOption(MetaSettings.Option.EXACT);
         setAvailableOptions(MetaSettings.Option.EXACT, MetaSettings.Option.HIGHER, MetaSettings.Option.LOWER);
     }

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/CustomDurabilityMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/CustomDurabilityMeta.java
@@ -28,6 +28,7 @@ public class CustomDurabilityMeta extends Meta {
     public static final NamespacedKey KEY = NamespacedKey.wolfyutilties("custom_durability");
 
     public CustomDurabilityMeta() {
+        super(KEY);
         setOption(MetaSettings.Option.EXACT);
         setAvailableOptions(MetaSettings.Option.EXACT, MetaSettings.Option.HIGHER, MetaSettings.Option.LOWER);
     }

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/CustomDurabilityMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/CustomDurabilityMeta.java
@@ -26,7 +26,7 @@ public class CustomDurabilityMeta extends Meta {
 
     public CustomDurabilityMeta() {
         setOption(MetaSettings.Option.EXACT);
-        setAvailableOptions(MetaSettings.Option.EXACT, MetaSettings.Option.IGNORE, MetaSettings.Option.HIGHER, MetaSettings.Option.LOWER);
+        setAvailableOptions(MetaSettings.Option.EXACT, MetaSettings.Option.HIGHER, MetaSettings.Option.LOWER);
     }
 
     @Override

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/CustomDurabilityMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/CustomDurabilityMeta.java
@@ -18,6 +18,7 @@
 
 package me.wolfyscript.utilities.api.inventory.custom_items.meta;
 
+import me.wolfyscript.utilities.api.inventory.custom_items.CustomItem;
 import me.wolfyscript.utilities.util.NamespacedKey;
 import me.wolfyscript.utilities.util.inventory.item_builder.ItemBuilder;
 import org.bukkit.inventory.meta.Damageable;
@@ -29,12 +30,11 @@ public class CustomDurabilityMeta extends Meta {
 
     public CustomDurabilityMeta() {
         super(KEY);
-        setOption(MetaSettings.Option.EXACT);
         setAvailableOptions(MetaSettings.Option.EXACT, MetaSettings.Option.HIGHER, MetaSettings.Option.LOWER);
     }
 
     @Override
-    public boolean check(ItemBuilder itemOther, ItemBuilder item) {
+    public boolean check(CustomItem item, ItemBuilder itemOther) {
         boolean meta0 = item.hasCustomDurability();
         boolean meta1 = itemOther.hasCustomDurability();
         if (meta0 && meta1) {

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/CustomDurabilityMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/CustomDurabilityMeta.java
@@ -21,8 +21,6 @@ package me.wolfyscript.utilities.api.inventory.custom_items.meta;
 import me.wolfyscript.utilities.api.inventory.custom_items.CustomItem;
 import me.wolfyscript.utilities.util.NamespacedKey;
 import me.wolfyscript.utilities.util.inventory.item_builder.ItemBuilder;
-import org.bukkit.inventory.meta.Damageable;
-import org.bukkit.inventory.meta.ItemMeta;
 
 public class CustomDurabilityMeta extends Meta {
 

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/CustomDurabilityMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/CustomDurabilityMeta.java
@@ -18,11 +18,14 @@
 
 package me.wolfyscript.utilities.api.inventory.custom_items.meta;
 
+import me.wolfyscript.utilities.util.NamespacedKey;
 import me.wolfyscript.utilities.util.inventory.item_builder.ItemBuilder;
 import org.bukkit.inventory.meta.Damageable;
 import org.bukkit.inventory.meta.ItemMeta;
 
 public class CustomDurabilityMeta extends Meta {
+
+    public static final NamespacedKey KEY = NamespacedKey.wolfyutilties("custom_durability");
 
     public CustomDurabilityMeta() {
         setOption(MetaSettings.Option.EXACT);

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/CustomDurabilityMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/CustomDurabilityMeta.java
@@ -33,29 +33,13 @@ public class CustomDurabilityMeta extends Meta {
     public boolean check(ItemBuilder itemOther, ItemBuilder item) {
         boolean meta0 = item.hasCustomDurability();
         boolean meta1 = itemOther.hasCustomDurability();
-        ItemMeta metaOther = itemOther.getItemMeta();
-        ItemMeta meta = item.getItemMeta();
         if (meta0 && meta1) {
-            switch (option) {
-                case EXACT:
-                    return itemOther.getCustomDurability() == item.getCustomDurability();
-                case IGNORE:
-                    itemOther.setCustomDurability(0);
-                    item.setCustomDurability(0);
-                    ((Damageable) metaOther).setDamage(0);
-                    ((Damageable) meta).setDamage(0);
-                    itemOther.setItemMeta(metaOther);
-                    item.setItemMeta(meta);
-                    return true;
-                case LOWER:
-                    return itemOther.getCustomDurability() < item.getCustomDurability();
-                case HIGHER:
-                    return itemOther.getCustomDurability() > item.getCustomDurability();
-                default:
-                    return true;
-            }
-        } else {
-            return !meta0 && !meta1;
-        }
+            return switch (option) {
+                case EXACT -> itemOther.getCustomDurability() == item.getCustomDurability();
+                case LOWER -> itemOther.getCustomDurability() < item.getCustomDurability();
+                case HIGHER -> itemOther.getCustomDurability() > item.getCustomDurability();
+                default -> false;
+            };
+        } else return !meta0 && !meta1;
     }
 }

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/CustomItemTagMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/CustomItemTagMeta.java
@@ -19,6 +19,8 @@
 package me.wolfyscript.utilities.api.inventory.custom_items.meta;
 
 
+import me.wolfyscript.utilities.api.WolfyUtilities;
+import me.wolfyscript.utilities.api.inventory.custom_items.CustomItem;
 import me.wolfyscript.utilities.util.inventory.item_builder.ItemBuilder;
 import org.bukkit.NamespacedKey;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -28,7 +30,7 @@ import java.util.Objects;
 
 public class CustomItemTagMeta extends Meta {
 
-    public static final NamespacedKey namespacedKey = new NamespacedKey("wolfyutilities", "custom_item");
+    public static final NamespacedKey namespacedKey = new NamespacedKey(WolfyUtilities.getWUPlugin(), "custom_item");
 
     public CustomItemTagMeta() {
         setOption(MetaSettings.Option.EXACT);
@@ -37,19 +39,12 @@ public class CustomItemTagMeta extends Meta {
 
     @Override
     public boolean check(ItemBuilder itemOther, ItemBuilder item) {
-        ItemMeta meta1 = item.getItemMeta();
-        ItemMeta meta2 = itemOther.getItemMeta();
-        if (hasKey(meta1)) {
-            return hasKey(meta2) && Objects.equals(getKey(meta1), getKey(meta2));
+        var key = CustomItem.getKeyOfItemMeta(item.getItemMeta());
+        var keyOther = CustomItem.getKeyOfItemMeta(itemOther.getItemMeta());
+        if (key != null) {
+            return keyOther != null && Objects.equals(key, keyOther);
         }
-        return !hasKey(meta2);
+        return keyOther == null;
     }
 
-    private boolean hasKey(ItemMeta meta) {
-        return meta.getPersistentDataContainer().has(namespacedKey, PersistentDataType.STRING);
-    }
-
-    private me.wolfyscript.utilities.util.NamespacedKey getKey(ItemMeta meta) {
-        return me.wolfyscript.utilities.util.NamespacedKey.of(meta.getPersistentDataContainer().get(namespacedKey, PersistentDataType.STRING));
-    }
 }

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/CustomItemTagMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/CustomItemTagMeta.java
@@ -31,7 +31,6 @@ public class CustomItemTagMeta extends Meta {
 
     public CustomItemTagMeta() {
         super(KEY);
-        setAvailableOptions(MetaSettings.Option.EXACT);
     }
 
     @JsonIgnore
@@ -47,7 +46,7 @@ public class CustomItemTagMeta extends Meta {
     }
 
     @Override
-    public boolean check(ItemBuilder itemOther, ItemBuilder item) {
+    public boolean check(CustomItem item, ItemBuilder itemOther) {
         var key = CustomItem.getKeyOfItemMeta(item.getItemMeta());
         var keyOther = CustomItem.getKeyOfItemMeta(itemOther.getItemMeta());
         if (key != null) {

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/CustomItemTagMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/CustomItemTagMeta.java
@@ -31,8 +31,8 @@ public class CustomItemTagMeta extends Meta {
     public static final NamespacedKey namespacedKey = new NamespacedKey("wolfyutilities", "custom_item");
 
     public CustomItemTagMeta() {
-        setOption(MetaSettings.Option.IGNORE);
-        setAvailableOptions(MetaSettings.Option.IGNORE, MetaSettings.Option.EXACT);
+        setOption(MetaSettings.Option.EXACT);
+        setAvailableOptions(MetaSettings.Option.EXACT);
     }
 
     @Override

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/CustomItemTagMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/CustomItemTagMeta.java
@@ -18,6 +18,7 @@
 
 package me.wolfyscript.utilities.api.inventory.custom_items.meta;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import me.wolfyscript.utilities.api.inventory.custom_items.CustomItem;
 import me.wolfyscript.utilities.util.NamespacedKey;
 import me.wolfyscript.utilities.util.inventory.item_builder.ItemBuilder;
@@ -29,8 +30,20 @@ public class CustomItemTagMeta extends Meta {
     public static final NamespacedKey KEY = NamespacedKey.wolfyutilties("customitem_tag");
 
     public CustomItemTagMeta() {
-        setOption(MetaSettings.Option.EXACT);
+        super(KEY);
         setAvailableOptions(MetaSettings.Option.EXACT);
+    }
+
+    @JsonIgnore
+    @Override
+    public MetaSettings.Option getOption() {
+        return super.getOption();
+    }
+
+    @JsonIgnore
+    @Override
+    public void setOption(MetaSettings.Option option) {
+        super.setOption(MetaSettings.Option.EXACT);
     }
 
     @Override

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/CustomItemTagMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/CustomItemTagMeta.java
@@ -19,13 +19,16 @@
 package me.wolfyscript.utilities.api.inventory.custom_items.meta;
 
 
-import me.wolfyscript.utilities.api.WolfyUtilities;
 import me.wolfyscript.utilities.util.inventory.item_builder.ItemBuilder;
 import org.bukkit.NamespacedKey;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.persistence.PersistentDataType;
 
+import java.util.Objects;
+
 public class CustomItemTagMeta extends Meta {
+
+    public static final NamespacedKey namespacedKey = new NamespacedKey("wolfyutilities", "custom_item");
 
     public CustomItemTagMeta() {
         setOption(MetaSettings.Option.IGNORE);
@@ -34,19 +37,19 @@ public class CustomItemTagMeta extends Meta {
 
     @Override
     public boolean check(ItemBuilder itemOther, ItemBuilder item) {
-        ItemMeta meta1 = itemOther.getItemMeta();
-        ItemMeta meta2 = item.getItemMeta();
-        if (option.equals(MetaSettings.Option.IGNORE)) {
-            NamespacedKey namespacedKey = new NamespacedKey(WolfyUtilities.getWUPlugin(), "custom_item");
-            if (meta1.getPersistentDataContainer().has(namespacedKey, PersistentDataType.STRING)) {
-                meta1.getPersistentDataContainer().remove(namespacedKey);
-            }
-            if (meta2.getPersistentDataContainer().has(namespacedKey, PersistentDataType.STRING)) {
-                meta2.getPersistentDataContainer().remove(namespacedKey);
-            }
+        ItemMeta meta1 = item.getItemMeta();
+        ItemMeta meta2 = itemOther.getItemMeta();
+        if (hasKey(meta1)) {
+            return hasKey(meta2) && Objects.equals(getKey(meta1), getKey(meta2));
         }
-        itemOther.setItemMeta(meta1);
-        item.setItemMeta(meta2);
-        return true;
+        return !hasKey(meta2);
+    }
+
+    private boolean hasKey(ItemMeta meta) {
+        return meta.getPersistentDataContainer().has(namespacedKey, PersistentDataType.STRING);
+    }
+
+    private me.wolfyscript.utilities.util.NamespacedKey getKey(ItemMeta meta) {
+        return me.wolfyscript.utilities.util.NamespacedKey.of(meta.getPersistentDataContainer().get(namespacedKey, PersistentDataType.STRING));
     }
 }

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/CustomItemTagMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/CustomItemTagMeta.java
@@ -18,19 +18,15 @@
 
 package me.wolfyscript.utilities.api.inventory.custom_items.meta;
 
-
-import me.wolfyscript.utilities.api.WolfyUtilities;
 import me.wolfyscript.utilities.api.inventory.custom_items.CustomItem;
+import me.wolfyscript.utilities.util.NamespacedKey;
 import me.wolfyscript.utilities.util.inventory.item_builder.ItemBuilder;
-import org.bukkit.NamespacedKey;
-import org.bukkit.inventory.meta.ItemMeta;
-import org.bukkit.persistence.PersistentDataType;
 
 import java.util.Objects;
 
 public class CustomItemTagMeta extends Meta {
 
-    public static final NamespacedKey namespacedKey = new NamespacedKey(WolfyUtilities.getWUPlugin(), "custom_item");
+    public static final NamespacedKey KEY = NamespacedKey.wolfyutilties("customitem_tag");
 
     public CustomItemTagMeta() {
         setOption(MetaSettings.Option.EXACT);

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/CustomModelDataMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/CustomModelDataMeta.java
@@ -19,10 +19,13 @@
 package me.wolfyscript.utilities.api.inventory.custom_items.meta;
 
 
+import me.wolfyscript.utilities.util.NamespacedKey;
 import me.wolfyscript.utilities.util.inventory.item_builder.ItemBuilder;
 import org.bukkit.inventory.meta.ItemMeta;
 
 public class CustomModelDataMeta extends Meta {
+
+    public static final NamespacedKey KEY = NamespacedKey.wolfyutilties("custom_model_data");
 
     public CustomModelDataMeta() {
         setOption(MetaSettings.Option.EXACT);

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/CustomModelDataMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/CustomModelDataMeta.java
@@ -28,6 +28,7 @@ public class CustomModelDataMeta extends Meta {
     public static final NamespacedKey KEY = NamespacedKey.wolfyutilties("custom_model_data");
 
     public CustomModelDataMeta() {
+        super(KEY);
         setOption(MetaSettings.Option.EXACT);
         setAvailableOptions(MetaSettings.Option.EXACT, MetaSettings.Option.HIGHER, MetaSettings.Option.LOWER);
     }

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/CustomModelDataMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/CustomModelDataMeta.java
@@ -33,19 +33,10 @@ public class CustomModelDataMeta extends Meta {
     public boolean check(ItemBuilder itemOther, ItemBuilder item) {
         ItemMeta meta1 = itemOther.getItemMeta();
         ItemMeta meta2 = item.getItemMeta();
-        switch (option) {
-            case IGNORE:
-                meta1.setCustomModelData(0);
-                meta2.setCustomModelData(0);
-                itemOther.setItemMeta(meta1);
-                item.setItemMeta(meta2);
-                return true;
-            case LOWER:
-                return meta1.getCustomModelData() < meta2.getCustomModelData();
-            case HIGHER:
-                return meta1.getCustomModelData() > meta2.getCustomModelData();
-            default:
-                return true;
-        }
+        return switch (option) {
+            case LOWER -> meta1.getCustomModelData() < meta2.getCustomModelData();
+            case HIGHER -> meta1.getCustomModelData() > meta2.getCustomModelData();
+            default -> false;
+        };
     }
 }

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/CustomModelDataMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/CustomModelDataMeta.java
@@ -26,7 +26,7 @@ public class CustomModelDataMeta extends Meta {
 
     public CustomModelDataMeta() {
         setOption(MetaSettings.Option.EXACT);
-        setAvailableOptions(MetaSettings.Option.EXACT, MetaSettings.Option.IGNORE, MetaSettings.Option.HIGHER, MetaSettings.Option.LOWER);
+        setAvailableOptions(MetaSettings.Option.EXACT, MetaSettings.Option.HIGHER, MetaSettings.Option.LOWER);
     }
 
     @Override

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/CustomModelDataMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/CustomModelDataMeta.java
@@ -19,6 +19,7 @@
 package me.wolfyscript.utilities.api.inventory.custom_items.meta;
 
 
+import me.wolfyscript.utilities.api.inventory.custom_items.CustomItem;
 import me.wolfyscript.utilities.util.NamespacedKey;
 import me.wolfyscript.utilities.util.inventory.item_builder.ItemBuilder;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -29,12 +30,11 @@ public class CustomModelDataMeta extends Meta {
 
     public CustomModelDataMeta() {
         super(KEY);
-        setOption(MetaSettings.Option.EXACT);
         setAvailableOptions(MetaSettings.Option.EXACT, MetaSettings.Option.HIGHER, MetaSettings.Option.LOWER);
     }
 
     @Override
-    public boolean check(ItemBuilder itemOther, ItemBuilder item) {
+    public boolean check(CustomItem item, ItemBuilder itemOther) {
         ItemMeta meta1 = itemOther.getItemMeta();
         ItemMeta meta2 = item.getItemMeta();
         return switch (option) {

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/DamageMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/DamageMeta.java
@@ -29,6 +29,7 @@ public class DamageMeta extends Meta {
     public static final NamespacedKey KEY = NamespacedKey.wolfyutilties("damage");
 
     public DamageMeta() {
+        super(KEY);
         setOption(MetaSettings.Option.EXACT);
         setAvailableOptions(MetaSettings.Option.EXACT, MetaSettings.Option.HIGHER, MetaSettings.Option.LOWER);
     }

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/DamageMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/DamageMeta.java
@@ -19,6 +19,7 @@
 package me.wolfyscript.utilities.api.inventory.custom_items.meta;
 
 
+import me.wolfyscript.utilities.api.inventory.custom_items.CustomItem;
 import me.wolfyscript.utilities.util.NamespacedKey;
 import me.wolfyscript.utilities.util.inventory.item_builder.ItemBuilder;
 import org.bukkit.inventory.meta.Damageable;
@@ -30,12 +31,11 @@ public class DamageMeta extends Meta {
 
     public DamageMeta() {
         super(KEY);
-        setOption(MetaSettings.Option.EXACT);
         setAvailableOptions(MetaSettings.Option.EXACT, MetaSettings.Option.HIGHER, MetaSettings.Option.LOWER);
     }
 
     @Override
-    public boolean check(ItemBuilder itemOther, ItemBuilder item) {
+    public boolean check(CustomItem item, ItemBuilder itemOther) {
         ItemMeta metaOther = itemOther.getItemMeta();
         ItemMeta meta = item.getItemMeta();
         return switch (option) {

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/DamageMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/DamageMeta.java
@@ -27,7 +27,7 @@ public class DamageMeta extends Meta {
 
     public DamageMeta() {
         setOption(MetaSettings.Option.EXACT);
-        setAvailableOptions(MetaSettings.Option.EXACT, MetaSettings.Option.IGNORE, MetaSettings.Option.HIGHER, MetaSettings.Option.LOWER);
+        setAvailableOptions(MetaSettings.Option.EXACT, MetaSettings.Option.HIGHER, MetaSettings.Option.LOWER);
     }
 
     @Override

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/DamageMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/DamageMeta.java
@@ -34,21 +34,11 @@ public class DamageMeta extends Meta {
     public boolean check(ItemBuilder itemOther, ItemBuilder item) {
         ItemMeta metaOther = itemOther.getItemMeta();
         ItemMeta meta = item.getItemMeta();
-        switch (option) {
-            case EXACT:
-                return ((Damageable)metaOther).getDamage() == ((Damageable)meta).getDamage();
-            case IGNORE:
-                ((Damageable) metaOther).setDamage(0);
-                ((Damageable) meta).setDamage(0);
-                itemOther.setItemMeta(metaOther);
-                item.setItemMeta(meta);
-                return true;
-            case LOWER:
-                return ((Damageable) metaOther).getDamage() < ((Damageable) meta).getDamage();
-            case HIGHER:
-                return ((Damageable) metaOther).getDamage() > ((Damageable) meta).getDamage();
-            default:
-                return false;
-        }
+        return switch (option) {
+            case EXACT -> ((Damageable) metaOther).getDamage() == ((Damageable) meta).getDamage();
+            case LOWER -> ((Damageable) metaOther).getDamage() < ((Damageable) meta).getDamage();
+            case HIGHER -> ((Damageable) metaOther).getDamage() > ((Damageable) meta).getDamage();
+            default -> false;
+        };
     }
 }

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/DamageMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/DamageMeta.java
@@ -19,11 +19,14 @@
 package me.wolfyscript.utilities.api.inventory.custom_items.meta;
 
 
+import me.wolfyscript.utilities.util.NamespacedKey;
 import me.wolfyscript.utilities.util.inventory.item_builder.ItemBuilder;
 import org.bukkit.inventory.meta.Damageable;
 import org.bukkit.inventory.meta.ItemMeta;
 
 public class DamageMeta extends Meta {
+
+    public static final NamespacedKey KEY = NamespacedKey.wolfyutilties("damage");
 
     public DamageMeta() {
         setOption(MetaSettings.Option.EXACT);

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/DamageMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/DamageMeta.java
@@ -18,7 +18,6 @@
 
 package me.wolfyscript.utilities.api.inventory.custom_items.meta;
 
-
 import me.wolfyscript.utilities.api.inventory.custom_items.CustomItem;
 import me.wolfyscript.utilities.util.NamespacedKey;
 import me.wolfyscript.utilities.util.inventory.item_builder.ItemBuilder;

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/EnchantMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/EnchantMeta.java
@@ -20,6 +20,7 @@ package me.wolfyscript.utilities.api.inventory.custom_items.meta;
 
 
 import me.wolfyscript.utilities.util.inventory.item_builder.ItemBuilder;
+import org.bukkit.inventory.meta.ItemMeta;
 
 public class EnchantMeta extends Meta {
 
@@ -30,10 +31,10 @@ public class EnchantMeta extends Meta {
 
     @Override
     public boolean check(ItemBuilder itemOther, ItemBuilder item) {
-        if (option.equals(MetaSettings.Option.IGNORE)) {
-            itemOther.getItemMeta().getEnchants().keySet().forEach(itemOther::removeEnchantment);
-            item.getItemMeta().getEnchants().keySet().forEach(item::removeEnchantment);
-        }
-        return true;
+        ItemMeta metaOther = itemOther.getItemMeta();
+        ItemMeta meta = item.getItemMeta();
+        if (meta.hasEnchants()) {
+            return metaOther.hasEnchants() && meta.getEnchants().equals(metaOther.getEnchants());
+        } else return !metaOther.hasEnchants();
     }
 }

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/EnchantMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/EnchantMeta.java
@@ -19,10 +19,13 @@
 package me.wolfyscript.utilities.api.inventory.custom_items.meta;
 
 
+import me.wolfyscript.utilities.util.NamespacedKey;
 import me.wolfyscript.utilities.util.inventory.item_builder.ItemBuilder;
 import org.bukkit.inventory.meta.ItemMeta;
 
 public class EnchantMeta extends Meta {
+
+    public static final NamespacedKey KEY = NamespacedKey.wolfyutilties("enchant");
 
     public EnchantMeta() {
         setOption(MetaSettings.Option.EXACT);

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/EnchantMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/EnchantMeta.java
@@ -28,6 +28,7 @@ public class EnchantMeta extends Meta {
     public static final NamespacedKey KEY = NamespacedKey.wolfyutilties("enchant");
 
     public EnchantMeta() {
+        super(KEY);
         setOption(MetaSettings.Option.EXACT);
         setAvailableOptions(MetaSettings.Option.EXACT);
     }

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/EnchantMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/EnchantMeta.java
@@ -19,6 +19,7 @@
 package me.wolfyscript.utilities.api.inventory.custom_items.meta;
 
 
+import me.wolfyscript.utilities.api.inventory.custom_items.CustomItem;
 import me.wolfyscript.utilities.util.NamespacedKey;
 import me.wolfyscript.utilities.util.inventory.item_builder.ItemBuilder;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -29,12 +30,10 @@ public class EnchantMeta extends Meta {
 
     public EnchantMeta() {
         super(KEY);
-        setOption(MetaSettings.Option.EXACT);
-        setAvailableOptions(MetaSettings.Option.EXACT);
     }
 
     @Override
-    public boolean check(ItemBuilder itemOther, ItemBuilder item) {
+    public boolean check(CustomItem item, ItemBuilder itemOther) {
         ItemMeta metaOther = itemOther.getItemMeta();
         ItemMeta meta = item.getItemMeta();
         if (meta.hasEnchants()) {

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/EnchantMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/EnchantMeta.java
@@ -26,7 +26,7 @@ public class EnchantMeta extends Meta {
 
     public EnchantMeta() {
         setOption(MetaSettings.Option.EXACT);
-        setAvailableOptions(MetaSettings.Option.EXACT, MetaSettings.Option.IGNORE);
+        setAvailableOptions(MetaSettings.Option.EXACT);
     }
 
     @Override

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/FlagsMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/FlagsMeta.java
@@ -24,7 +24,7 @@ public class FlagsMeta extends Meta {
 
     public FlagsMeta() {
         setOption(MetaSettings.Option.EXACT);
-        setAvailableOptions(MetaSettings.Option.EXACT, MetaSettings.Option.IGNORE);
+        setAvailableOptions(MetaSettings.Option.EXACT);
     }
 
     @Override

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/FlagsMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/FlagsMeta.java
@@ -26,6 +26,7 @@ public class FlagsMeta extends Meta {
     public static final NamespacedKey KEY = NamespacedKey.wolfyutilties("flags");
 
     public FlagsMeta() {
+        super(KEY);
         setOption(MetaSettings.Option.EXACT);
         setAvailableOptions(MetaSettings.Option.EXACT);
     }

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/FlagsMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/FlagsMeta.java
@@ -18,7 +18,6 @@
 
 package me.wolfyscript.utilities.api.inventory.custom_items.meta;
 
-
 import me.wolfyscript.utilities.util.inventory.item_builder.ItemBuilder;
 
 public class FlagsMeta extends Meta {
@@ -30,10 +29,6 @@ public class FlagsMeta extends Meta {
 
     @Override
     public boolean check(ItemBuilder itemOther, ItemBuilder item) {
-        if (option.equals(MetaSettings.Option.IGNORE)) {
-            itemOther.getItemMeta().getItemFlags().forEach(itemOther::removeItemFlags);
-            item.getItemMeta().getItemFlags().forEach(item::removeItemFlags);
-        }
-        return true;
+        return itemOther.getItemMeta().getItemFlags().containsAll(item.getItemMeta().getItemFlags());
     }
 }

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/FlagsMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/FlagsMeta.java
@@ -18,9 +18,12 @@
 
 package me.wolfyscript.utilities.api.inventory.custom_items.meta;
 
+import me.wolfyscript.utilities.util.NamespacedKey;
 import me.wolfyscript.utilities.util.inventory.item_builder.ItemBuilder;
 
 public class FlagsMeta extends Meta {
+
+    public static final NamespacedKey KEY = NamespacedKey.wolfyutilties("flags");
 
     public FlagsMeta() {
         setOption(MetaSettings.Option.EXACT);

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/FlagsMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/FlagsMeta.java
@@ -18,6 +18,7 @@
 
 package me.wolfyscript.utilities.api.inventory.custom_items.meta;
 
+import me.wolfyscript.utilities.api.inventory.custom_items.CustomItem;
 import me.wolfyscript.utilities.util.NamespacedKey;
 import me.wolfyscript.utilities.util.inventory.item_builder.ItemBuilder;
 
@@ -27,12 +28,10 @@ public class FlagsMeta extends Meta {
 
     public FlagsMeta() {
         super(KEY);
-        setOption(MetaSettings.Option.EXACT);
-        setAvailableOptions(MetaSettings.Option.EXACT);
     }
 
     @Override
-    public boolean check(ItemBuilder itemOther, ItemBuilder item) {
+    public boolean check(CustomItem item, ItemBuilder itemOther) {
         return itemOther.getItemMeta().getItemFlags().containsAll(item.getItemMeta().getItemFlags());
     }
 }

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/LoreMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/LoreMeta.java
@@ -30,6 +30,7 @@ public class LoreMeta extends Meta {
     public static final NamespacedKey KEY = NamespacedKey.wolfyutilties("lore");
 
     public LoreMeta() {
+        super(KEY);
         setOption(MetaSettings.Option.EXACT);
         setAvailableOptions(MetaSettings.Option.EXACT);
     }

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/LoreMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/LoreMeta.java
@@ -19,6 +19,7 @@
 package me.wolfyscript.utilities.api.inventory.custom_items.meta;
 
 
+import me.wolfyscript.utilities.api.inventory.custom_items.CustomItem;
 import me.wolfyscript.utilities.util.NamespacedKey;
 import me.wolfyscript.utilities.util.inventory.item_builder.ItemBuilder;
 
@@ -31,12 +32,10 @@ public class LoreMeta extends Meta {
 
     public LoreMeta() {
         super(KEY);
-        setOption(MetaSettings.Option.EXACT);
-        setAvailableOptions(MetaSettings.Option.EXACT);
     }
 
     @Override
-    public boolean check(ItemBuilder itemOther, ItemBuilder item) {
+    public boolean check(CustomItem item, ItemBuilder itemOther) {
         return Objects.equals(item.getItemMeta().getLore(), itemOther.getItemMeta().getLore());
     }
 }

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/LoreMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/LoreMeta.java
@@ -19,12 +19,15 @@
 package me.wolfyscript.utilities.api.inventory.custom_items.meta;
 
 
+import me.wolfyscript.utilities.util.NamespacedKey;
 import me.wolfyscript.utilities.util.inventory.item_builder.ItemBuilder;
 
 import java.util.ArrayList;
 import java.util.Objects;
 
 public class LoreMeta extends Meta {
+
+    public static final NamespacedKey KEY = NamespacedKey.wolfyutilties("lore");
 
     public LoreMeta() {
         setOption(MetaSettings.Option.EXACT);

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/LoreMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/LoreMeta.java
@@ -23,7 +23,6 @@ import me.wolfyscript.utilities.api.inventory.custom_items.CustomItem;
 import me.wolfyscript.utilities.util.NamespacedKey;
 import me.wolfyscript.utilities.util.inventory.item_builder.ItemBuilder;
 
-import java.util.ArrayList;
 import java.util.Objects;
 
 public class LoreMeta extends Meta {

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/LoreMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/LoreMeta.java
@@ -22,20 +22,17 @@ package me.wolfyscript.utilities.api.inventory.custom_items.meta;
 import me.wolfyscript.utilities.util.inventory.item_builder.ItemBuilder;
 
 import java.util.ArrayList;
+import java.util.Objects;
 
 public class LoreMeta extends Meta {
 
     public LoreMeta() {
         setOption(MetaSettings.Option.EXACT);
-        setAvailableOptions(MetaSettings.Option.EXACT, MetaSettings.Option.IGNORE);
+        setAvailableOptions(MetaSettings.Option.EXACT);
     }
 
     @Override
     public boolean check(ItemBuilder itemOther, ItemBuilder item) {
-        if (option.equals(MetaSettings.Option.IGNORE)) {
-            itemOther.setLore(new ArrayList<>());
-            item.setLore(new ArrayList<>());
-        }
-        return true;
+        return Objects.equals(item.getItemMeta().getLore(), itemOther.getItemMeta().getLore());
     }
 }

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/Meta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/Meta.java
@@ -18,10 +18,7 @@
 
 package me.wolfyscript.utilities.api.inventory.custom_items.meta;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.annotation.JsonTypeIdResolver;
 import com.fasterxml.jackson.databind.annotation.JsonTypeResolver;
@@ -41,14 +38,19 @@ import java.util.Objects;
 @JsonTypeResolver(KeyedTypeResolver.class)
 @JsonTypeIdResolver(KeyedTypeIdResolver.class)
 @JsonTypeInfo(use = JsonTypeInfo.Id.CUSTOM, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "key")
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 @JsonPropertyOrder("key")
 public abstract class Meta implements Keyed {
 
-    protected MetaSettings.Option option;
+    protected MetaSettings.Option option = MetaSettings.Option.EXACT;
 
-    private NamespacedKey key;
+    private final NamespacedKey key;
     @JsonIgnore
-    private List<MetaSettings.Option> availableOptions;
+    private List<MetaSettings.Option> availableOptions = List.of(MetaSettings.Option.EXACT);
+
+    protected Meta(NamespacedKey key) {
+        this.key = key;
+    }
 
     public MetaSettings.Option getOption() {
         return option;
@@ -112,8 +114,7 @@ public abstract class Meta implements Keyed {
 
         public M provide() {
             try {
-                M meta = type.getDeclaredConstructor().newInstance();
-                return meta;
+                return type.getDeclaredConstructor().newInstance();
             } catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
                 e.printStackTrace();
             }

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/Meta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/Meta.java
@@ -19,6 +19,7 @@
 package me.wolfyscript.utilities.api.inventory.custom_items.meta;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -45,7 +46,6 @@ public abstract class Meta implements Keyed {
 
     protected MetaSettings.Option option;
 
-    @JsonIgnore
     private NamespacedKey key;
     @JsonIgnore
     private List<MetaSettings.Option> availableOptions;
@@ -88,13 +88,10 @@ public abstract class Meta implements Keyed {
         return Objects.hash(key, option, availableOptions);
     }
 
+    @JsonIgnore
     @Override
     public final NamespacedKey getNamespacedKey() {
         return key;
-    }
-
-    final void setNamespacedKey(NamespacedKey namespacedKey) {
-        this.key = namespacedKey;
     }
 
     @Deprecated
@@ -116,7 +113,6 @@ public abstract class Meta implements Keyed {
         public M provide() {
             try {
                 M meta = type.getDeclaredConstructor().newInstance();
-                meta.setNamespacedKey(namespacedKey);
                 return meta;
             } catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
                 e.printStackTrace();
@@ -124,13 +120,9 @@ public abstract class Meta implements Keyed {
             return null;
         }
 
+        @Deprecated
         public M parse(JsonNode node) {
-            M meta = JacksonUtil.getObjectMapper().convertValue(node, type);
-            if (meta != null) {
-                meta.setNamespacedKey(namespacedKey);
-                return meta;
-            }
-            return null;
+            return JacksonUtil.getObjectMapper().convertValue(node, type);
         }
 
     }

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/Meta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/Meta.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.annotation.JsonTypeIdResolver;
 import com.fasterxml.jackson.databind.annotation.JsonTypeResolver;
+import me.wolfyscript.utilities.api.inventory.custom_items.CustomItem;
 import me.wolfyscript.utilities.util.Keyed;
 import me.wolfyscript.utilities.util.NamespacedKey;
 import me.wolfyscript.utilities.util.inventory.item_builder.ItemBuilder;
@@ -42,9 +43,9 @@ import java.util.Objects;
 @JsonPropertyOrder("key")
 public abstract class Meta implements Keyed {
 
-    protected MetaSettings.Option option = MetaSettings.Option.EXACT;
-
     private final NamespacedKey key;
+
+    protected MetaSettings.Option option = MetaSettings.Option.EXACT;
     @JsonIgnore
     private List<MetaSettings.Option> availableOptions = List.of(MetaSettings.Option.EXACT);
 
@@ -75,7 +76,12 @@ public abstract class Meta implements Keyed {
         }
     }
 
-    public abstract boolean check(ItemBuilder itemOther, ItemBuilder item);
+    @Deprecated
+    public boolean check(ItemBuilder itemOther, ItemBuilder item) {
+        return true;
+    }
+
+    public abstract boolean check(CustomItem item, ItemBuilder itemOther);
 
     @Override
     public boolean equals(Object o) {

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/Meta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/Meta.java
@@ -19,11 +19,17 @@
 package me.wolfyscript.utilities.api.inventory.custom_items.meta;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.annotation.JsonTypeIdResolver;
+import com.fasterxml.jackson.databind.annotation.JsonTypeResolver;
 import me.wolfyscript.utilities.util.Keyed;
 import me.wolfyscript.utilities.util.NamespacedKey;
 import me.wolfyscript.utilities.util.inventory.item_builder.ItemBuilder;
 import me.wolfyscript.utilities.util.json.jackson.JacksonUtil;
+import me.wolfyscript.utilities.util.json.jackson.KeyedTypeIdResolver;
+import me.wolfyscript.utilities.util.json.jackson.KeyedTypeResolver;
 import org.jetbrains.annotations.NotNull;
 
 import java.lang.reflect.InvocationTargetException;
@@ -31,6 +37,10 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
+@JsonTypeResolver(KeyedTypeResolver.class)
+@JsonTypeIdResolver(KeyedTypeIdResolver.class)
+@JsonTypeInfo(use = JsonTypeInfo.Id.CUSTOM, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "key")
+@JsonPropertyOrder("key")
 public abstract class Meta implements Keyed {
 
     protected MetaSettings.Option option;

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/Meta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/Meta.java
@@ -36,7 +36,7 @@ public abstract class Meta implements Keyed {
     protected MetaSettings.Option option;
 
     @JsonIgnore
-    private NamespacedKey namespacedKey;
+    private NamespacedKey key;
     @JsonIgnore
     private List<MetaSettings.Option> availableOptions;
 
@@ -70,23 +70,24 @@ public abstract class Meta implements Keyed {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         Meta meta = (Meta) o;
-        return Objects.equals(namespacedKey, meta.namespacedKey) && option == meta.option && Objects.equals(availableOptions, meta.availableOptions);
+        return Objects.equals(key, meta.key) && option == meta.option && Objects.equals(availableOptions, meta.availableOptions);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(namespacedKey, option, availableOptions);
+        return Objects.hash(key, option, availableOptions);
     }
 
     @Override
     public final NamespacedKey getNamespacedKey() {
-        return namespacedKey;
+        return key;
     }
 
     final void setNamespacedKey(NamespacedKey namespacedKey) {
-        this.namespacedKey = namespacedKey;
+        this.key = namespacedKey;
     }
 
+    @Deprecated
     public static class Provider<M extends Meta> implements Keyed {
 
         private final NamespacedKey namespacedKey;

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/Meta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/Meta.java
@@ -18,7 +18,10 @@
 
 package me.wolfyscript.utilities.api.inventory.custom_items.meta;
 
-import com.fasterxml.jackson.annotation.*;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.annotation.JsonTypeIdResolver;
 import com.fasterxml.jackson.databind.annotation.JsonTypeResolver;

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/MetaSettings.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/MetaSettings.java
@@ -21,6 +21,7 @@ package me.wolfyscript.utilities.api.inventory.custom_items.meta;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.base.Preconditions;
+import me.wolfyscript.utilities.api.inventory.custom_items.CustomItem;
 import me.wolfyscript.utilities.util.inventory.item_builder.ItemBuilder;
 import org.jetbrains.annotations.NotNull;
 
@@ -63,7 +64,11 @@ public class MetaSettings {
     }
 
     public boolean check(ItemBuilder itemOther, ItemBuilder item) {
-        return checks.stream().allMatch(meta -> meta.check(itemOther, item));
+        return true;
+    }
+
+    public boolean check(CustomItem item, ItemBuilder itemOther) {
+        return checks.stream().allMatch(meta -> meta.check(item, itemOther));
     }
 
     public enum Option {
@@ -72,7 +77,7 @@ public class MetaSettings {
          * This option was originally used to indicate if the meta check should be active.
          * Now it is no longer used (Only to convert old data), because checks that are not added to the settings are well... not checked anyway.
          */
-        @Deprecated(forRemoval = true) IGNORE,
+        @Deprecated IGNORE,
         HIGHER,
         HIGHER_EXACT,
         LOWER,

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/MetaSettings.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/MetaSettings.java
@@ -90,6 +90,10 @@ public class MetaSettings extends HashMap<NamespacedKey, Meta> {
         checks.add(meta);
     }
 
+    public void clearChecks() {
+        checks.clear();
+    }
+
     public List<Meta> getChecks() {
         return List.copyOf(checks);
     }

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/MetaSettings.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/MetaSettings.java
@@ -25,7 +25,9 @@ import me.wolfyscript.utilities.api.inventory.custom_items.CustomItem;
 import me.wolfyscript.utilities.util.inventory.item_builder.ItemBuilder;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 public class MetaSettings {

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/MetaSettings.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/MetaSettings.java
@@ -19,7 +19,7 @@
 package me.wolfyscript.utilities.api.inventory.custom_items.meta;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.base.Preconditions;
 import me.wolfyscript.utilities.util.inventory.item_builder.ItemBuilder;
 import org.jetbrains.annotations.NotNull;
@@ -31,7 +31,6 @@ public class MetaSettings {
 
     public static final String CHECKS_KEY = "checks";
 
-    @JsonProperty
     private final List<Meta> checks;
 
     /**
@@ -58,6 +57,7 @@ public class MetaSettings {
         return List.copyOf(checks);
     }
 
+    @JsonIgnore
     public boolean isEmpty() {
         return checks.isEmpty();
     }

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/MetaSettings.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/MetaSettings.java
@@ -18,56 +18,80 @@
 
 package me.wolfyscript.utilities.api.inventory.custom_items.meta;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.base.Preconditions;
 import me.wolfyscript.utilities.util.NamespacedKey;
 import me.wolfyscript.utilities.util.Registry;
 import me.wolfyscript.utilities.util.inventory.item_builder.ItemBuilder;
 import me.wolfyscript.utilities.util.json.jackson.JacksonUtil;
+import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Locale;
-import java.util.Set;
+import java.util.*;
 
 @JsonDeserialize(using = MetaSettings.Deserializer.class)
 public class MetaSettings extends HashMap<NamespacedKey, Meta> {
 
-    private final Set<Meta> checks = new HashSet<>();
+    private static final String CHECKS_KEY = "checks";
 
+    private final List<Meta> checks;
+
+    /**
+     * Creates a new settings object with an empty list of checks.
+     */
     public MetaSettings() {
-        Registry.META_PROVIDER.entrySet().forEach(entry -> put(entry.getKey(), entry.getValue().provide()));
+        checks = new ArrayList<>();
     }
 
-    public MetaSettings(JsonNode jsonNode) {
-        this();
+    /**
+     * This constructor is only used for serializing the object from a JsonNode.
+     * It will convert the old data to the new system if necessary.
+     *
+     * @param jsonNode The {@link JsonNode} to load the data from.
+     */
+    private MetaSettings(JsonNode jsonNode) {
         if (jsonNode instanceof ObjectNode node) {
-            //TODO: Replace Meta.Provider with the new KeyedTypeIdResolver
-            if (!node.has("checks")) {
+            if (!node.has(CHECKS_KEY)) {
+                checks = new ArrayList<>();
+                //Convert old meta to new format.
                 node.fields().forEachRemaining(entry -> {
-                    String key = entry.getKey().toLowerCase(Locale.ROOT);
-                    NamespacedKey namespacedKey = key.contains(":") ? NamespacedKey.of(key) : NamespacedKey.wolfyutilties(key);
-                    Meta.Provider<?> provider = Registry.META_PROVIDER.get(namespacedKey);
-                    if (provider != null) {
-                        Meta meta;
-                        if (entry.getValue().isTextual()) {
-                            meta = provider.provide();
-                            meta.setOption(JacksonUtil.getObjectMapper().convertValue(entry.getValue(), MetaSettings.Option.class));
-                        } else {
-                            meta = provider.parse(entry.getValue());
+                    if(entry.getValue() instanceof ObjectNode value) {
+                        String key = entry.getKey().toLowerCase(Locale.ROOT);
+                        NamespacedKey namespacedKey = key.contains(":") ? NamespacedKey.of(key) : NamespacedKey.wolfyutilties(key);
+                        if (namespacedKey != null) {
+                            value.put("key", String.valueOf(namespacedKey));
+                            Meta meta = JacksonUtil.getObjectMapper().convertValue(value, Meta.class);
+                            if (meta != null && !meta.getOption().equals(Option.IGNORE)) {
+                                checks.add(meta);
+                            }
                         }
-                        put(namespacedKey, meta);
                     }
                 });
             } else {
-
-
+                JsonNode checksNode = node.get(CHECKS_KEY);
+                checks = JacksonUtil.getObjectMapper().convertValue(checksNode, new TypeReference<>() {});
             }
+        } else {
+            checks = new ArrayList<>();
         }
+    }
+
+    /**
+     * @param meta The {@link Meta} to add to the list of checks. Cannot be null, and must not have the {@link Option#IGNORE}, or it will throw an exception!
+     */
+    public void addCheck(@NotNull Meta meta) {
+        Objects.requireNonNull(meta, "Meta check cannot be null!");
+        Preconditions.checkArgument(!meta.getOption().equals(Option.IGNORE), "Deprecated option! Ignored check cannot be added!");
+        checks.add(meta);
+    }
+
+    public List<Meta> getChecks() {
+        return List.copyOf(checks);
     }
 
     public boolean check(ItemBuilder itemOther, ItemBuilder item) {
@@ -75,7 +99,17 @@ public class MetaSettings extends HashMap<NamespacedKey, Meta> {
     }
 
     public enum Option {
-        EXACT, @Deprecated(forRemoval = true) IGNORE, HIGHER, HIGHER_EXACT, LOWER, LOWER_EXACT, HIGHER_LOWER
+        EXACT,
+        /**
+         * This option was originally used to indicate if the meta check should be active.
+         * Now it is no longer used (Only to convert old data), because checks that are not added to the settings are well... not checked anyway.
+         */
+        @Deprecated(forRemoval = true) IGNORE,
+        HIGHER,
+        HIGHER_EXACT,
+        LOWER,
+        LOWER_EXACT,
+        HIGHER_LOWER
     }
 
     public static class Deserializer extends StdDeserializer<MetaSettings> {

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/NBTTagMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/NBTTagMeta.java
@@ -18,11 +18,15 @@
 
 package me.wolfyscript.utilities.api.inventory.custom_items.meta;
 
+import me.wolfyscript.utilities.util.NamespacedKey;
 import me.wolfyscript.utilities.util.inventory.item_builder.ItemBuilder;
 
 public class NBTTagMeta extends Meta {
 
+    public static final NamespacedKey KEY = NamespacedKey.wolfyutilties("player_head");
+
     public NBTTagMeta() {
+        super(KEY);
         setOption(MetaSettings.Option.EXACT);
         setAvailableOptions(MetaSettings.Option.EXACT);
     }

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/NBTTagMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/NBTTagMeta.java
@@ -24,7 +24,7 @@ public class NBTTagMeta extends Meta {
 
     public NBTTagMeta() {
         setOption(MetaSettings.Option.EXACT);
-        setAvailableOptions(MetaSettings.Option.EXACT, MetaSettings.Option.IGNORE);
+        setAvailableOptions(MetaSettings.Option.EXACT);
     }
 
     @Override

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/NBTTagMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/NBTTagMeta.java
@@ -29,6 +29,7 @@ public class NBTTagMeta extends Meta {
 
     @Override
     public boolean check(ItemBuilder itemOther, ItemBuilder item) {
-        return false;
+        //TODO
+        return true;
     }
 }

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/NBTTagMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/NBTTagMeta.java
@@ -18,6 +18,7 @@
 
 package me.wolfyscript.utilities.api.inventory.custom_items.meta;
 
+import me.wolfyscript.utilities.api.inventory.custom_items.CustomItem;
 import me.wolfyscript.utilities.util.NamespacedKey;
 import me.wolfyscript.utilities.util.inventory.item_builder.ItemBuilder;
 
@@ -27,12 +28,10 @@ public class NBTTagMeta extends Meta {
 
     public NBTTagMeta() {
         super(KEY);
-        setOption(MetaSettings.Option.EXACT);
-        setAvailableOptions(MetaSettings.Option.EXACT);
     }
 
     @Override
-    public boolean check(ItemBuilder itemOther, ItemBuilder item) {
+    public boolean check(CustomItem item, ItemBuilder itemOther) {
         //TODO
         return true;
     }

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/NameMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/NameMeta.java
@@ -25,7 +25,7 @@ public class NameMeta extends Meta {
 
     public NameMeta() {
         setOption(MetaSettings.Option.EXACT);
-        setAvailableOptions(MetaSettings.Option.EXACT, MetaSettings.Option.IGNORE);
+        setAvailableOptions(MetaSettings.Option.EXACT);
     }
 
     @Override

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/NameMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/NameMeta.java
@@ -19,6 +19,7 @@
 package me.wolfyscript.utilities.api.inventory.custom_items.meta;
 
 import me.wolfyscript.utilities.util.inventory.item_builder.ItemBuilder;
+import org.bukkit.inventory.meta.ItemMeta;
 
 public class NameMeta extends Meta {
 
@@ -28,11 +29,11 @@ public class NameMeta extends Meta {
     }
 
     @Override
-    public boolean check(ItemBuilder meta1, ItemBuilder meta2) {
-        if (option.equals(MetaSettings.Option.IGNORE)) {
-            meta1.setDisplayName(null);
-            meta2.setDisplayName(null);
-        }
-        return true;
+    public boolean check(ItemBuilder itemOther, ItemBuilder item) {
+        ItemMeta metaOther = itemOther.getItemMeta();
+        ItemMeta meta = item.getItemMeta();
+        if (meta.hasDisplayName()) {
+            return metaOther.hasDisplayName() && meta.getDisplayName().equals(metaOther.getDisplayName());
+        } else return !metaOther.hasDisplayName();
     }
 }

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/NameMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/NameMeta.java
@@ -27,6 +27,7 @@ public class NameMeta extends Meta {
     public static final NamespacedKey KEY = NamespacedKey.wolfyutilties("name");
 
     public NameMeta() {
+        super(KEY);
         setOption(MetaSettings.Option.EXACT);
         setAvailableOptions(MetaSettings.Option.EXACT);
     }

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/NameMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/NameMeta.java
@@ -18,10 +18,13 @@
 
 package me.wolfyscript.utilities.api.inventory.custom_items.meta;
 
+import me.wolfyscript.utilities.util.NamespacedKey;
 import me.wolfyscript.utilities.util.inventory.item_builder.ItemBuilder;
 import org.bukkit.inventory.meta.ItemMeta;
 
 public class NameMeta extends Meta {
+
+    public static final NamespacedKey KEY = NamespacedKey.wolfyutilties("name");
 
     public NameMeta() {
         setOption(MetaSettings.Option.EXACT);

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/NameMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/NameMeta.java
@@ -18,6 +18,7 @@
 
 package me.wolfyscript.utilities.api.inventory.custom_items.meta;
 
+import me.wolfyscript.utilities.api.inventory.custom_items.CustomItem;
 import me.wolfyscript.utilities.util.NamespacedKey;
 import me.wolfyscript.utilities.util.inventory.item_builder.ItemBuilder;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -28,12 +29,10 @@ public class NameMeta extends Meta {
 
     public NameMeta() {
         super(KEY);
-        setOption(MetaSettings.Option.EXACT);
-        setAvailableOptions(MetaSettings.Option.EXACT);
     }
 
     @Override
-    public boolean check(ItemBuilder itemOther, ItemBuilder item) {
+    public boolean check(CustomItem item, ItemBuilder itemOther) {
         ItemMeta metaOther = itemOther.getItemMeta();
         ItemMeta meta = item.getItemMeta();
         if (meta.hasDisplayName()) {

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/PlayerHeadMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/PlayerHeadMeta.java
@@ -26,7 +26,7 @@ public class PlayerHeadMeta extends Meta {
 
     public PlayerHeadMeta() {
         setOption(MetaSettings.Option.EXACT);
-        setAvailableOptions(MetaSettings.Option.EXACT, MetaSettings.Option.IGNORE);
+        setAvailableOptions(MetaSettings.Option.EXACT);
     }
 
     @Override

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/PlayerHeadMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/PlayerHeadMeta.java
@@ -22,7 +22,6 @@ package me.wolfyscript.utilities.api.inventory.custom_items.meta;
 import me.wolfyscript.utilities.api.inventory.custom_items.CustomItem;
 import me.wolfyscript.utilities.util.NamespacedKey;
 import me.wolfyscript.utilities.util.inventory.item_builder.ItemBuilder;
-import org.bukkit.inventory.meta.ItemMeta;
 
 public class PlayerHeadMeta extends Meta {
 

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/PlayerHeadMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/PlayerHeadMeta.java
@@ -28,6 +28,7 @@ public class PlayerHeadMeta extends Meta {
     public static final NamespacedKey KEY = NamespacedKey.wolfyutilties("player_head");
 
     public PlayerHeadMeta() {
+        super(KEY);
         setOption(MetaSettings.Option.EXACT);
         setAvailableOptions(MetaSettings.Option.EXACT);
     }

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/PlayerHeadMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/PlayerHeadMeta.java
@@ -19,6 +19,7 @@
 package me.wolfyscript.utilities.api.inventory.custom_items.meta;
 
 
+import me.wolfyscript.utilities.api.inventory.custom_items.CustomItem;
 import me.wolfyscript.utilities.util.NamespacedKey;
 import me.wolfyscript.utilities.util.inventory.item_builder.ItemBuilder;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -29,12 +30,10 @@ public class PlayerHeadMeta extends Meta {
 
     public PlayerHeadMeta() {
         super(KEY);
-        setOption(MetaSettings.Option.EXACT);
-        setAvailableOptions(MetaSettings.Option.EXACT);
     }
 
     @Override
-    public boolean check(ItemBuilder itemOther, ItemBuilder item) {
+    public boolean check(CustomItem item, ItemBuilder itemOther) {
         String valueOther = itemOther.getPlayerHeadValue();
         String value = item.getPlayerHeadValue();
         return valueOther.equals(value);

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/PlayerHeadMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/PlayerHeadMeta.java
@@ -19,10 +19,13 @@
 package me.wolfyscript.utilities.api.inventory.custom_items.meta;
 
 
+import me.wolfyscript.utilities.util.NamespacedKey;
 import me.wolfyscript.utilities.util.inventory.item_builder.ItemBuilder;
 import org.bukkit.inventory.meta.ItemMeta;
 
 public class PlayerHeadMeta extends Meta {
+
+    public static final NamespacedKey KEY = NamespacedKey.wolfyutilties("player_head");
 
     public PlayerHeadMeta() {
         setOption(MetaSettings.Option.EXACT);

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/PlayerHeadMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/PlayerHeadMeta.java
@@ -20,6 +20,7 @@ package me.wolfyscript.utilities.api.inventory.custom_items.meta;
 
 
 import me.wolfyscript.utilities.util.inventory.item_builder.ItemBuilder;
+import org.bukkit.inventory.meta.ItemMeta;
 
 public class PlayerHeadMeta extends Meta {
 
@@ -30,15 +31,8 @@ public class PlayerHeadMeta extends Meta {
 
     @Override
     public boolean check(ItemBuilder itemOther, ItemBuilder item) {
-        if(option.equals(MetaSettings.Option.EXACT)){
-            String valueOther = itemOther.getPlayerHeadValue();
-            String value = item.getPlayerHeadValue();
-            if(!valueOther.equals(value)){
-                return false;
-            }
-        }
-        itemOther.removePlayerHeadValue();
-        item.removePlayerHeadValue();
-        return true;
+        String valueOther = itemOther.getPlayerHeadValue();
+        String value = item.getPlayerHeadValue();
+        return valueOther.equals(value);
     }
 }

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/PotionMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/PotionMeta.java
@@ -30,6 +30,7 @@ public class PotionMeta extends Meta {
     public static final NamespacedKey KEY = NamespacedKey.wolfyutilties("potion");
 
     public PotionMeta() {
+        super(KEY);
         setOption(MetaSettings.Option.EXACT);
         setAvailableOptions(MetaSettings.Option.EXACT);
     }

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/PotionMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/PotionMeta.java
@@ -19,12 +19,15 @@
 package me.wolfyscript.utilities.api.inventory.custom_items.meta;
 
 
+import me.wolfyscript.utilities.util.NamespacedKey;
 import me.wolfyscript.utilities.util.inventory.item_builder.ItemBuilder;
 import org.bukkit.inventory.meta.ItemMeta;
 
 import java.util.Objects;
 
 public class PotionMeta extends Meta {
+
+    public static final NamespacedKey KEY = NamespacedKey.wolfyutilties("potion");
 
     public PotionMeta() {
         setOption(MetaSettings.Option.EXACT);

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/PotionMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/PotionMeta.java
@@ -22,6 +22,8 @@ package me.wolfyscript.utilities.api.inventory.custom_items.meta;
 import me.wolfyscript.utilities.util.inventory.item_builder.ItemBuilder;
 import org.bukkit.inventory.meta.ItemMeta;
 
+import java.util.Objects;
+
 public class PotionMeta extends Meta {
 
     public PotionMeta() {
@@ -33,15 +35,25 @@ public class PotionMeta extends Meta {
     public boolean check(ItemBuilder itemOther, ItemBuilder item) {
         ItemMeta meta1 = itemOther.getItemMeta();
         ItemMeta meta2 = item.getItemMeta();
-
-        if (meta1 instanceof org.bukkit.inventory.meta.PotionMeta && meta2 instanceof org.bukkit.inventory.meta.PotionMeta) {
-            if (option.equals(MetaSettings.Option.IGNORE)) {
-                ((org.bukkit.inventory.meta.PotionMeta) meta1).clearCustomEffects();
-                ((org.bukkit.inventory.meta.PotionMeta) meta2).clearCustomEffects();
-                itemOther.setItemMeta(meta1);
-                item.setItemMeta(meta2);
+        if (meta2 instanceof org.bukkit.inventory.meta.PotionMeta) {
+            if (meta1 instanceof org.bukkit.inventory.meta.PotionMeta) {
+                org.bukkit.inventory.meta.PotionMeta metaThat = (org.bukkit.inventory.meta.PotionMeta) itemOther.getItemMeta();
+                org.bukkit.inventory.meta.PotionMeta metaThis = (org.bukkit.inventory.meta.PotionMeta) item.getItemMeta();
+                if (metaThis.getBasePotionData().getType().equals(metaThat.getBasePotionData().getType())) {
+                    if (metaThis.hasCustomEffects()) {
+                        if (!metaThat.hasCustomEffects() || !metaThis.getCustomEffects().equals(metaThat.getCustomEffects())) {
+                            return false;
+                        }
+                    } else if (metaThat.hasCustomEffects()) {
+                        return false;
+                    }
+                    if (metaThis.hasColor()) {
+                        return metaThat.hasColor() && Objects.equals(metaThis.getColor(), metaThat.getColor());
+                    } else return !metaThat.hasColor();
+                }
             }
+            return false;
         }
-        return true;
+        return !(meta1 instanceof org.bukkit.inventory.meta.PotionMeta);
     }
 }

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/PotionMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/PotionMeta.java
@@ -19,6 +19,7 @@
 package me.wolfyscript.utilities.api.inventory.custom_items.meta;
 
 
+import me.wolfyscript.utilities.api.inventory.custom_items.CustomItem;
 import me.wolfyscript.utilities.util.NamespacedKey;
 import me.wolfyscript.utilities.util.inventory.item_builder.ItemBuilder;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -31,12 +32,10 @@ public class PotionMeta extends Meta {
 
     public PotionMeta() {
         super(KEY);
-        setOption(MetaSettings.Option.EXACT);
-        setAvailableOptions(MetaSettings.Option.EXACT);
     }
 
     @Override
-    public boolean check(ItemBuilder itemOther, ItemBuilder item) {
+    public boolean check(CustomItem item, ItemBuilder itemOther) {
         ItemMeta meta1 = itemOther.getItemMeta();
         ItemMeta meta2 = item.getItemMeta();
         if (meta2 instanceof org.bukkit.inventory.meta.PotionMeta) {

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/PotionMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/PotionMeta.java
@@ -28,7 +28,7 @@ public class PotionMeta extends Meta {
 
     public PotionMeta() {
         setOption(MetaSettings.Option.EXACT);
-        setAvailableOptions(MetaSettings.Option.EXACT, MetaSettings.Option.IGNORE);
+        setAvailableOptions(MetaSettings.Option.EXACT);
     }
 
     @Override

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/RepairCostMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/RepairCostMeta.java
@@ -27,7 +27,7 @@ public class RepairCostMeta extends Meta {
 
     public RepairCostMeta() {
         setOption(MetaSettings.Option.EXACT);
-        setAvailableOptions(MetaSettings.Option.EXACT, MetaSettings.Option.IGNORE, MetaSettings.Option.HIGHER, MetaSettings.Option.LOWER);
+        setAvailableOptions(MetaSettings.Option.EXACT, MetaSettings.Option.HIGHER, MetaSettings.Option.LOWER);
     }
 
     @Override

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/RepairCostMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/RepairCostMeta.java
@@ -29,6 +29,7 @@ public class RepairCostMeta extends Meta {
     public static final NamespacedKey KEY = NamespacedKey.wolfyutilties("repair_cost");
 
     public RepairCostMeta() {
+        super(KEY);
         setOption(MetaSettings.Option.EXACT);
         setAvailableOptions(MetaSettings.Option.EXACT, MetaSettings.Option.HIGHER, MetaSettings.Option.LOWER);
     }

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/RepairCostMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/RepairCostMeta.java
@@ -19,6 +19,7 @@
 package me.wolfyscript.utilities.api.inventory.custom_items.meta;
 
 
+import me.wolfyscript.utilities.api.inventory.custom_items.CustomItem;
 import me.wolfyscript.utilities.util.NamespacedKey;
 import me.wolfyscript.utilities.util.inventory.item_builder.ItemBuilder;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -30,12 +31,11 @@ public class RepairCostMeta extends Meta {
 
     public RepairCostMeta() {
         super(KEY);
-        setOption(MetaSettings.Option.EXACT);
         setAvailableOptions(MetaSettings.Option.EXACT, MetaSettings.Option.HIGHER, MetaSettings.Option.LOWER);
     }
 
     @Override
-    public boolean check(ItemBuilder itemOther, ItemBuilder item) {
+    public boolean check(CustomItem item, ItemBuilder itemOther) {
         ItemMeta metaOther = itemOther.getItemMeta();
         ItemMeta meta = item.getItemMeta();
         if (meta instanceof Repairable) {

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/RepairCostMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/RepairCostMeta.java
@@ -34,24 +34,17 @@ public class RepairCostMeta extends Meta {
     public boolean check(ItemBuilder itemOther, ItemBuilder item) {
         ItemMeta metaOther = itemOther.getItemMeta();
         ItemMeta meta = item.getItemMeta();
-        if (metaOther instanceof Repairable && meta instanceof Repairable) {
-            switch (option) {
-                case EXACT:
-                    return ((Repairable) metaOther).getRepairCost() == ((Repairable) meta).getRepairCost();
-                case IGNORE:
-                    ((Repairable) metaOther).setRepairCost(0);
-                    ((Repairable) meta).setRepairCost(0);
-                    itemOther.setItemMeta(metaOther);
-                    item.setItemMeta(meta);
-                    return true;
-                case LOWER:
-                    return ((Repairable) metaOther).getRepairCost() < ((Repairable) meta).getRepairCost();
-                case HIGHER:
-                    return ((Repairable) metaOther).getRepairCost() > ((Repairable) meta).getRepairCost();
-                default:
-                    return true;
+        if (meta instanceof Repairable) {
+            if (metaOther instanceof Repairable) {
+                return switch (option) {
+                    case EXACT -> ((Repairable) metaOther).getRepairCost() == ((Repairable) meta).getRepairCost();
+                    case LOWER -> ((Repairable) metaOther).getRepairCost() < ((Repairable) meta).getRepairCost();
+                    case HIGHER -> ((Repairable) metaOther).getRepairCost() > ((Repairable) meta).getRepairCost();
+                    default -> false;
+                };
             }
+            return false;
         }
-        return true;
+        return !(metaOther instanceof Repairable);
     }
 }

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/RepairCostMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/RepairCostMeta.java
@@ -19,11 +19,14 @@
 package me.wolfyscript.utilities.api.inventory.custom_items.meta;
 
 
+import me.wolfyscript.utilities.util.NamespacedKey;
 import me.wolfyscript.utilities.util.inventory.item_builder.ItemBuilder;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.Repairable;
 
 public class RepairCostMeta extends Meta {
+
+    public static final NamespacedKey KEY = NamespacedKey.wolfyutilties("repair_cost");
 
     public RepairCostMeta() {
         setOption(MetaSettings.Option.EXACT);

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/RepairCostMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/RepairCostMeta.java
@@ -18,7 +18,6 @@
 
 package me.wolfyscript.utilities.api.inventory.custom_items.meta;
 
-
 import me.wolfyscript.utilities.api.inventory.custom_items.CustomItem;
 import me.wolfyscript.utilities.util.NamespacedKey;
 import me.wolfyscript.utilities.util.inventory.item_builder.ItemBuilder;

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/UnbreakableMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/UnbreakableMeta.java
@@ -26,7 +26,7 @@ public class UnbreakableMeta extends Meta {
 
     public UnbreakableMeta() {
         setOption(MetaSettings.Option.EXACT);
-        setAvailableOptions(MetaSettings.Option.EXACT, MetaSettings.Option.IGNORE);
+        setAvailableOptions(MetaSettings.Option.EXACT);
     }
 
     @Override

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/UnbreakableMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/UnbreakableMeta.java
@@ -31,14 +31,6 @@ public class UnbreakableMeta extends Meta {
 
     @Override
     public boolean check(ItemBuilder itemOther, ItemBuilder item) {
-        ItemMeta meta1 = itemOther.getItemMeta();
-        ItemMeta meta2 = item.getItemMeta();
-        if (option.equals(MetaSettings.Option.IGNORE)) {
-            meta1.setUnbreakable(false);
-            meta2.setUnbreakable(false);
-            itemOther.setItemMeta(meta1);
-            item.setItemMeta(meta2);
-        }
-        return true;
+        return item.getItemMeta().isUnbreakable() == itemOther.getItemMeta().isUnbreakable();
     }
 }

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/UnbreakableMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/UnbreakableMeta.java
@@ -19,10 +19,13 @@
 package me.wolfyscript.utilities.api.inventory.custom_items.meta;
 
 
+import me.wolfyscript.utilities.util.NamespacedKey;
 import me.wolfyscript.utilities.util.inventory.item_builder.ItemBuilder;
 import org.bukkit.inventory.meta.ItemMeta;
 
 public class UnbreakableMeta extends Meta {
+
+    public static final NamespacedKey KEY = NamespacedKey.wolfyutilties("unbreakable");
 
     public UnbreakableMeta() {
         setOption(MetaSettings.Option.EXACT);

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/UnbreakableMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/UnbreakableMeta.java
@@ -18,11 +18,9 @@
 
 package me.wolfyscript.utilities.api.inventory.custom_items.meta;
 
-
 import me.wolfyscript.utilities.api.inventory.custom_items.CustomItem;
 import me.wolfyscript.utilities.util.NamespacedKey;
 import me.wolfyscript.utilities.util.inventory.item_builder.ItemBuilder;
-import org.bukkit.inventory.meta.ItemMeta;
 
 public class UnbreakableMeta extends Meta {
 

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/UnbreakableMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/UnbreakableMeta.java
@@ -28,6 +28,7 @@ public class UnbreakableMeta extends Meta {
     public static final NamespacedKey KEY = NamespacedKey.wolfyutilties("unbreakable");
 
     public UnbreakableMeta() {
+        super(KEY);
         setOption(MetaSettings.Option.EXACT);
         setAvailableOptions(MetaSettings.Option.EXACT);
     }

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/UnbreakableMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/UnbreakableMeta.java
@@ -19,6 +19,7 @@
 package me.wolfyscript.utilities.api.inventory.custom_items.meta;
 
 
+import me.wolfyscript.utilities.api.inventory.custom_items.CustomItem;
 import me.wolfyscript.utilities.util.NamespacedKey;
 import me.wolfyscript.utilities.util.inventory.item_builder.ItemBuilder;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -29,12 +30,10 @@ public class UnbreakableMeta extends Meta {
 
     public UnbreakableMeta() {
         super(KEY);
-        setOption(MetaSettings.Option.EXACT);
-        setAvailableOptions(MetaSettings.Option.EXACT);
     }
 
     @Override
-    public boolean check(ItemBuilder itemOther, ItemBuilder item) {
+    public boolean check(CustomItem item, ItemBuilder itemOther) {
         return item.getItemMeta().isUnbreakable() == itemOther.getItemMeta().isUnbreakable();
     }
 }

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/references/VanillaRef.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/references/VanillaRef.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import me.wolfyscript.utilities.api.inventory.custom_items.CustomItem;
 import me.wolfyscript.utilities.util.json.jackson.JacksonUtil;
+import org.bukkit.Bukkit;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.Nullable;
 
@@ -57,8 +58,8 @@ public class VanillaRef extends APIReference {
     }
 
     @Override
-    public boolean isValidItem(ItemStack itemStack) {
-        return true;
+    public boolean isValidItem(ItemStack other) {
+        return itemStack.isSimilar(other);
     }
 
     @Override

--- a/core/src/main/java/me/wolfyscript/utilities/util/ClassRegistry.java
+++ b/core/src/main/java/me/wolfyscript/utilities/util/ClassRegistry.java
@@ -19,6 +19,7 @@
 package me.wolfyscript.utilities.util;
 
 import com.google.common.base.Preconditions;
+import me.wolfyscript.utilities.api.inventory.custom_items.meta.Meta;
 import me.wolfyscript.utilities.util.particles.animators.Animator;
 import me.wolfyscript.utilities.util.particles.timer.Timer;
 import org.jetbrains.annotations.NotNull;
@@ -42,6 +43,7 @@ public interface ClassRegistry<V extends Keyed> extends Iterable<Class<? extends
 
     SimpleClassRegistry<Animator> PARTICLE_ANIMATORS = new SimpleClassRegistry<>();
     SimpleClassRegistry<Timer> PARTICLE_TIMER = new SimpleClassRegistry<>();
+    SimpleClassRegistry<Meta> META_CHECKS = new SimpleClassRegistry<>();
 
     /**
      * Get the value of the registry by it's {@link NamespacedKey}

--- a/core/src/main/java/me/wolfyscript/utilities/util/ClassRegistry.java
+++ b/core/src/main/java/me/wolfyscript/utilities/util/ClassRegistry.java
@@ -43,7 +43,7 @@ public interface ClassRegistry<V extends Keyed> extends Iterable<Class<? extends
 
     SimpleClassRegistry<Animator> PARTICLE_ANIMATORS = new SimpleClassRegistry<>();
     SimpleClassRegistry<Timer> PARTICLE_TIMER = new SimpleClassRegistry<>();
-    SimpleClassRegistry<Meta> META_CHECKS = new SimpleClassRegistry<>();
+    SimpleClassRegistry<Meta> NBT_CHECKS = new SimpleClassRegistry<>();
 
     /**
      * Get the value of the registry by it's {@link NamespacedKey}

--- a/core/src/main/java/me/wolfyscript/utilities/util/Registry.java
+++ b/core/src/main/java/me/wolfyscript/utilities/util/Registry.java
@@ -64,6 +64,8 @@ public interface Registry<V extends Keyed> extends Iterable<V> {
      * And also the Recipe Book uses a CustomData object to store some data.
      */
     Registry<CustomData.Provider<?>> CUSTOM_ITEM_DATA = new SimpleRegistry<>();
+
+    @Deprecated(forRemoval = true)
     MetaRegistry META_PROVIDER = new MetaRegistry();
 
     ParticleRegistry PARTICLE_EFFECTS = new ParticleRegistry();
@@ -224,6 +226,7 @@ public interface Registry<V extends Keyed> extends Iterable<V> {
         }
     }
 
+    @Deprecated(forRemoval = true)
     class MetaRegistry extends SimpleRegistry<Meta.Provider<?>> {
 
         public void register(NamespacedKey key, Class<? extends Meta> metaType) {

--- a/core/src/main/java/me/wolfyscript/utilities/util/Registry.java
+++ b/core/src/main/java/me/wolfyscript/utilities/util/Registry.java
@@ -229,6 +229,7 @@ public interface Registry<V extends Keyed> extends Iterable<V> {
     @Deprecated(forRemoval = true)
     class MetaRegistry extends SimpleRegistry<Meta.Provider<?>> {
 
+        @Deprecated
         public void register(NamespacedKey key, Class<? extends Meta> metaType) {
             register(new Meta.Provider<>(key, metaType));
         }

--- a/core/src/main/java/me/wolfyscript/utilities/util/particles/ParticleEffect.java
+++ b/core/src/main/java/me/wolfyscript/utilities/util/particles/ParticleEffect.java
@@ -185,10 +185,12 @@ public class ParticleEffect implements Keyed {
         this.extra = extra;
     }
 
+    @JsonGetter("timer")
     public Timer getTimeSupplier() {
         return timer;
     }
 
+    @JsonSetter("timer")
     public void setTimeSupplier(Timer timer) {
         this.timer = timer;
     }

--- a/pom.xml
+++ b/pom.xml
@@ -184,7 +184,7 @@
         <dependency>
             <groupId>net.Indyuce</groupId>
             <artifactId>mmoitems</artifactId>
-            <version>6.5.4</version>
+            <version>6.6.2</version>
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>

--- a/wolfyutilities/src/main/java/me/wolfyscript/utilities/main/WUPlugin.java
+++ b/wolfyutilities/src/main/java/me/wolfyscript/utilities/main/WUPlugin.java
@@ -137,21 +137,20 @@ public class WUPlugin extends JavaPlugin {
 
         //Register meta settings providers
         getLogger().info("Register Meta Setting providers");
-        Registry.MetaRegistry meta = Registry.META_PROVIDER;
-        meta.register(NamespacedKey.wolfyutilties("attributes_modifiers"), AttributesModifiersMeta.class);
-        meta.register(NamespacedKey.wolfyutilties("custom_damage"), CustomDamageMeta.class);
-        meta.register(NamespacedKey.wolfyutilties("custom_durability"), CustomDurabilityMeta.class);
-        meta.register(NamespacedKey.wolfyutilties("customitem_tag"), CustomItemTagMeta.class);
-        meta.register(NamespacedKey.wolfyutilties("custom_model_data"), CustomModelDataMeta.class);
-        meta.register(NamespacedKey.wolfyutilties("damage"), DamageMeta.class);
-        meta.register(NamespacedKey.wolfyutilties("enchant"), EnchantMeta.class);
-        meta.register(NamespacedKey.wolfyutilties("flags"), FlagsMeta.class);
-        meta.register(NamespacedKey.wolfyutilties("lore"), LoreMeta.class);
-        meta.register(NamespacedKey.wolfyutilties("name"), NameMeta.class);
-        meta.register(NamespacedKey.wolfyutilties("player_head"), PlayerHeadMeta.class);
-        meta.register(NamespacedKey.wolfyutilties("potion"), PotionMeta.class);
-        meta.register(NamespacedKey.wolfyutilties("repair_cost"), RepairCostMeta.class);
-        meta.register(NamespacedKey.wolfyutilties("unbreakable"), UnbreakableMeta.class);
+        ClassRegistry.META_CHECKS.register(NamespacedKey.wolfyutilties("attributes_modifiers"), AttributesModifiersMeta.class);
+        ClassRegistry.META_CHECKS.register(NamespacedKey.wolfyutilties("custom_damage"), CustomDamageMeta.class);
+        ClassRegistry.META_CHECKS.register(NamespacedKey.wolfyutilties("custom_durability"), CustomDurabilityMeta.class);
+        ClassRegistry.META_CHECKS.register(NamespacedKey.wolfyutilties("customitem_tag"), CustomItemTagMeta.class);
+        ClassRegistry.META_CHECKS.register(NamespacedKey.wolfyutilties("custom_model_data"), CustomModelDataMeta.class);
+        ClassRegistry.META_CHECKS.register(NamespacedKey.wolfyutilties("damage"), DamageMeta.class);
+        ClassRegistry.META_CHECKS.register(NamespacedKey.wolfyutilties("enchant"), EnchantMeta.class);
+        ClassRegistry.META_CHECKS.register(NamespacedKey.wolfyutilties("flags"), FlagsMeta.class);
+        ClassRegistry.META_CHECKS.register(NamespacedKey.wolfyutilties("lore"), LoreMeta.class);
+        ClassRegistry.META_CHECKS.register(NamespacedKey.wolfyutilties("name"), NameMeta.class);
+        ClassRegistry.META_CHECKS.register(NamespacedKey.wolfyutilties("player_head"), PlayerHeadMeta.class);
+        ClassRegistry.META_CHECKS.register(NamespacedKey.wolfyutilties("potion"), PotionMeta.class);
+        ClassRegistry.META_CHECKS.register(NamespacedKey.wolfyutilties("repair_cost"), RepairCostMeta.class);
+        ClassRegistry.META_CHECKS.register(NamespacedKey.wolfyutilties("unbreakable"), UnbreakableMeta.class);
 
         ClassRegistry.PARTICLE_ANIMATORS.register(AnimatorBasic.KEY, AnimatorBasic.class);
         ClassRegistry.PARTICLE_ANIMATORS.register(AnimatorSphere.KEY, AnimatorSphere.class);
@@ -161,6 +160,7 @@ public class WUPlugin extends JavaPlugin {
         ClassRegistry.PARTICLE_TIMER.register(TimerRandom.KEY, TimerRandom.class);
         ClassRegistry.PARTICLE_TIMER.register(TimerPi.KEY, TimerPi.class);
 
+        KeyedTypeIdResolver.registerTypeRegistry(Meta.class, ClassRegistry.META_CHECKS);
         KeyedTypeIdResolver.registerTypeRegistry(Animator.class, ClassRegistry.PARTICLE_ANIMATORS);
         KeyedTypeIdResolver.registerTypeRegistry(Timer.class, ClassRegistry.PARTICLE_TIMER);
     }

--- a/wolfyutilities/src/main/java/me/wolfyscript/utilities/main/WUPlugin.java
+++ b/wolfyutilities/src/main/java/me/wolfyscript/utilities/main/WUPlugin.java
@@ -133,20 +133,20 @@ public class WUPlugin extends JavaPlugin {
 
         //Register meta settings providers
         getLogger().info("Register CustomItem meta checks");
-        ClassRegistry.META_CHECKS.register(AttributesModifiersMeta.KEY, AttributesModifiersMeta.class);
-        ClassRegistry.META_CHECKS.register(CustomDamageMeta.KEY, CustomDamageMeta.class);
-        ClassRegistry.META_CHECKS.register(CustomDurabilityMeta.KEY, CustomDurabilityMeta.class);
-        ClassRegistry.META_CHECKS.register(CustomItemTagMeta.KEY, CustomItemTagMeta.class);
-        ClassRegistry.META_CHECKS.register(CustomModelDataMeta.KEY, CustomModelDataMeta.class);
-        ClassRegistry.META_CHECKS.register(DamageMeta.KEY, DamageMeta.class);
-        ClassRegistry.META_CHECKS.register(EnchantMeta.KEY, EnchantMeta.class);
-        ClassRegistry.META_CHECKS.register(FlagsMeta.KEY, FlagsMeta.class);
-        ClassRegistry.META_CHECKS.register(LoreMeta.KEY, LoreMeta.class);
-        ClassRegistry.META_CHECKS.register(NameMeta.KEY, NameMeta.class);
-        ClassRegistry.META_CHECKS.register(PlayerHeadMeta.KEY, PlayerHeadMeta.class);
-        ClassRegistry.META_CHECKS.register(PotionMeta.KEY, PotionMeta.class);
-        ClassRegistry.META_CHECKS.register(RepairCostMeta.KEY, RepairCostMeta.class);
-        ClassRegistry.META_CHECKS.register(UnbreakableMeta.KEY, UnbreakableMeta.class);
+        ClassRegistry.NBT_CHECKS.register(AttributesModifiersMeta.KEY, AttributesModifiersMeta.class);
+        ClassRegistry.NBT_CHECKS.register(CustomDamageMeta.KEY, CustomDamageMeta.class);
+        ClassRegistry.NBT_CHECKS.register(CustomDurabilityMeta.KEY, CustomDurabilityMeta.class);
+        ClassRegistry.NBT_CHECKS.register(CustomItemTagMeta.KEY, CustomItemTagMeta.class);
+        ClassRegistry.NBT_CHECKS.register(CustomModelDataMeta.KEY, CustomModelDataMeta.class);
+        ClassRegistry.NBT_CHECKS.register(DamageMeta.KEY, DamageMeta.class);
+        ClassRegistry.NBT_CHECKS.register(EnchantMeta.KEY, EnchantMeta.class);
+        ClassRegistry.NBT_CHECKS.register(FlagsMeta.KEY, FlagsMeta.class);
+        ClassRegistry.NBT_CHECKS.register(LoreMeta.KEY, LoreMeta.class);
+        ClassRegistry.NBT_CHECKS.register(NameMeta.KEY, NameMeta.class);
+        ClassRegistry.NBT_CHECKS.register(PlayerHeadMeta.KEY, PlayerHeadMeta.class);
+        ClassRegistry.NBT_CHECKS.register(PotionMeta.KEY, PotionMeta.class);
+        ClassRegistry.NBT_CHECKS.register(RepairCostMeta.KEY, RepairCostMeta.class);
+        ClassRegistry.NBT_CHECKS.register(UnbreakableMeta.KEY, UnbreakableMeta.class);
 
         ClassRegistry.PARTICLE_ANIMATORS.register(AnimatorBasic.KEY, AnimatorBasic.class);
         ClassRegistry.PARTICLE_ANIMATORS.register(AnimatorSphere.KEY, AnimatorSphere.class);
@@ -156,7 +156,7 @@ public class WUPlugin extends JavaPlugin {
         ClassRegistry.PARTICLE_TIMER.register(TimerRandom.KEY, TimerRandom.class);
         ClassRegistry.PARTICLE_TIMER.register(TimerPi.KEY, TimerPi.class);
 
-        KeyedTypeIdResolver.registerTypeRegistry(Meta.class, ClassRegistry.META_CHECKS);
+        KeyedTypeIdResolver.registerTypeRegistry(Meta.class, ClassRegistry.NBT_CHECKS);
         KeyedTypeIdResolver.registerTypeRegistry(Animator.class, ClassRegistry.PARTICLE_ANIMATORS);
         KeyedTypeIdResolver.registerTypeRegistry(Timer.class, ClassRegistry.PARTICLE_TIMER);
     }

--- a/wolfyutilities/src/main/java/me/wolfyscript/utilities/main/WUPlugin.java
+++ b/wolfyutilities/src/main/java/me/wolfyscript/utilities/main/WUPlugin.java
@@ -41,8 +41,6 @@ import me.wolfyscript.utilities.main.listeners.custom_item.CustomParticleListene
 import me.wolfyscript.utilities.main.messages.MessageFactory;
 import me.wolfyscript.utilities.main.messages.MessageHandler;
 import me.wolfyscript.utilities.util.ClassRegistry;
-import me.wolfyscript.utilities.util.NamespacedKey;
-import me.wolfyscript.utilities.util.Registry;
 import me.wolfyscript.utilities.util.entity.PlayerUtils;
 import me.wolfyscript.utilities.util.inventory.CreativeModeTab;
 import me.wolfyscript.utilities.util.inventory.item_builder.ItemBuilder;
@@ -71,8 +69,6 @@ import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.java.JavaPlugin;
 
-import java.io.File;
-import java.io.IOException;
 import java.util.Arrays;
 
 public class WUPlugin extends JavaPlugin {
@@ -136,21 +132,21 @@ public class WUPlugin extends JavaPlugin {
         //Register custom item data
 
         //Register meta settings providers
-        getLogger().info("Register Meta Setting providers");
-        ClassRegistry.META_CHECKS.register(NamespacedKey.wolfyutilties("attributes_modifiers"), AttributesModifiersMeta.class);
-        ClassRegistry.META_CHECKS.register(NamespacedKey.wolfyutilties("custom_damage"), CustomDamageMeta.class);
-        ClassRegistry.META_CHECKS.register(NamespacedKey.wolfyutilties("custom_durability"), CustomDurabilityMeta.class);
-        ClassRegistry.META_CHECKS.register(NamespacedKey.wolfyutilties("customitem_tag"), CustomItemTagMeta.class);
-        ClassRegistry.META_CHECKS.register(NamespacedKey.wolfyutilties("custom_model_data"), CustomModelDataMeta.class);
-        ClassRegistry.META_CHECKS.register(NamespacedKey.wolfyutilties("damage"), DamageMeta.class);
-        ClassRegistry.META_CHECKS.register(NamespacedKey.wolfyutilties("enchant"), EnchantMeta.class);
-        ClassRegistry.META_CHECKS.register(NamespacedKey.wolfyutilties("flags"), FlagsMeta.class);
-        ClassRegistry.META_CHECKS.register(NamespacedKey.wolfyutilties("lore"), LoreMeta.class);
-        ClassRegistry.META_CHECKS.register(NamespacedKey.wolfyutilties("name"), NameMeta.class);
-        ClassRegistry.META_CHECKS.register(NamespacedKey.wolfyutilties("player_head"), PlayerHeadMeta.class);
-        ClassRegistry.META_CHECKS.register(NamespacedKey.wolfyutilties("potion"), PotionMeta.class);
-        ClassRegistry.META_CHECKS.register(NamespacedKey.wolfyutilties("repair_cost"), RepairCostMeta.class);
-        ClassRegistry.META_CHECKS.register(NamespacedKey.wolfyutilties("unbreakable"), UnbreakableMeta.class);
+        getLogger().info("Register CustomItem meta checks");
+        ClassRegistry.META_CHECKS.register(AttributesModifiersMeta.KEY, AttributesModifiersMeta.class);
+        ClassRegistry.META_CHECKS.register(CustomDamageMeta.KEY, CustomDamageMeta.class);
+        ClassRegistry.META_CHECKS.register(CustomDurabilityMeta.KEY, CustomDurabilityMeta.class);
+        ClassRegistry.META_CHECKS.register(CustomItemTagMeta.KEY, CustomItemTagMeta.class);
+        ClassRegistry.META_CHECKS.register(CustomModelDataMeta.KEY, CustomModelDataMeta.class);
+        ClassRegistry.META_CHECKS.register(DamageMeta.KEY, DamageMeta.class);
+        ClassRegistry.META_CHECKS.register(EnchantMeta.KEY, EnchantMeta.class);
+        ClassRegistry.META_CHECKS.register(FlagsMeta.KEY, FlagsMeta.class);
+        ClassRegistry.META_CHECKS.register(LoreMeta.KEY, LoreMeta.class);
+        ClassRegistry.META_CHECKS.register(NameMeta.KEY, NameMeta.class);
+        ClassRegistry.META_CHECKS.register(PlayerHeadMeta.KEY, PlayerHeadMeta.class);
+        ClassRegistry.META_CHECKS.register(PotionMeta.KEY, PotionMeta.class);
+        ClassRegistry.META_CHECKS.register(RepairCostMeta.KEY, RepairCostMeta.class);
+        ClassRegistry.META_CHECKS.register(UnbreakableMeta.KEY, UnbreakableMeta.class);
 
         ClassRegistry.PARTICLE_ANIMATORS.register(AnimatorBasic.KEY, AnimatorBasic.class);
         ClassRegistry.PARTICLE_ANIMATORS.register(AnimatorSphere.KEY, AnimatorSphere.class);


### PR DESCRIPTION
The custom checks are now 100% modular.  
For each saved (and registered) CustomItem you can set so called NBT checks, that can replace the default check or extend it.

By default the CustomItem will use a single check with the key `wolfyutilities:customitem_tag`, which will just check for the namespaced key of the item.
There must at least one check, if you don't set one the default one is used.

To add different checks you need to configure the config of the item or add them via the API.
It uses a new field in the config called `nbtChecks` with a child `checks`, that is the actual the array that contains the checks.
```json
"nbtChecks" : {
    "checks" : [ {
      "key" : "wolfyutilities:customitem_tag"
    } ]
  }
```

You are also able to code and register your own checks (inside your plugins `onLoad()`). 
There isn't any wiki page for it you would have to look at the other checks and see how they are registered.