### PR TITLE
CustomItem old MetaSettings loading/conversion changes

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <artifactId>wolfyutilities-parent</artifactId>
         <groupId>com.wolfyscript.wolfyutilities</groupId>
-        <version>1.7.8.0</version>
+        <version>1.7.8.1</version>
     </parent>
     <dependencies>
         <dependency>

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/CustomItem.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/CustomItem.java
@@ -142,7 +142,7 @@ public class CustomItem extends AbstractItemBuilder<CustomItem> implements Keyed
     @JsonAlias("particles")
     private ParticleContent particleContent;
 
-    private boolean clearOldMetaSettings = false;
+    private boolean checkOldMetaSettings = true;
 
     @JsonCreator
     public CustomItem(@JsonProperty("apiReference") @JsonAlias({"item", "api_reference"}) APIReference apiReference) {
@@ -173,14 +173,14 @@ public class CustomItem extends AbstractItemBuilder<CustomItem> implements Keyed
     @JsonAnySetter
     protected void setOldProperties(String fieldKey, JsonNode value) throws JsonProcessingException {
         if (fieldKey.equals("advanced")) {
-            clearOldMetaSettings = !value.asBoolean();
+            checkOldMetaSettings = value.asBoolean();
         } else if (fieldKey.equals("metaSettings") || fieldKey.equals("meta")) {
             //Since the new system has its new field we need to update old appearances to the new system.
             JsonNode node = value.isTextual() ? JacksonUtil.getObjectMapper().readTree(value.asText()) : value;
             final List<Meta> checks;
             if (!node.has(MetaSettings.CHECKS_KEY)) {
                 checks = new ArrayList<>();
-                if (!clearOldMetaSettings) {
+                if (checkOldMetaSettings) {
                     //Convert old meta to new format.
                     node.fields().forEachRemaining(entry -> {
                         if (entry.getValue() instanceof ObjectNode entryVal) {
@@ -189,7 +189,7 @@ public class CustomItem extends AbstractItemBuilder<CustomItem> implements Keyed
                             if (namespacedKey != null) {
                                 entryVal.put("key", String.valueOf(namespacedKey));
                                 Meta meta = JacksonUtil.getObjectMapper().convertValue(entryVal, Meta.class);
-                                if (meta != null && !meta.getOption().equals(MetaSettings.Option.IGNORE)) {
+                                if (meta != null && !meta.getOption().equals(MetaSettings.Option.IGNORE) && !meta.getOption().equals(MetaSettings.Option.EXACT)) {
                                     checks.add(meta);
                                 }
                             }

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/CustomItemTagMeta.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/meta/CustomItemTagMeta.java
@@ -47,7 +47,7 @@ public class CustomItemTagMeta extends Meta {
 
     @Override
     public boolean check(CustomItem item, ItemBuilder itemOther) {
-        var key = CustomItem.getKeyOfItemMeta(item.getItemMeta());
+        var key = item.getNamespacedKey();
         var keyOther = CustomItem.getKeyOfItemMeta(itemOther.getItemMeta());
         if (key != null) {
             return keyOther != null && Objects.equals(key, keyOther);

--- a/nmsutil-v1_15_R1/pom.xml
+++ b/nmsutil-v1_15_R1/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>wolfyutilities-parent</artifactId>
         <groupId>com.wolfyscript.wolfyutilities</groupId>
-        <version>1.7.8.0</version>
+        <version>1.7.8.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil-v1_16_R1/pom.xml
+++ b/nmsutil-v1_16_R1/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>wolfyutilities-parent</artifactId>
         <groupId>com.wolfyscript.wolfyutilities</groupId>
-        <version>1.7.8.0</version>
+        <version>1.7.8.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil-v1_16_R2/pom.xml
+++ b/nmsutil-v1_16_R2/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>wolfyutilities-parent</artifactId>
         <groupId>com.wolfyscript.wolfyutilities</groupId>
-        <version>1.7.8.0</version>
+        <version>1.7.8.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil-v1_16_R3/pom.xml
+++ b/nmsutil-v1_16_R3/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>wolfyutilities-parent</artifactId>
         <groupId>com.wolfyscript.wolfyutilities</groupId>
-        <version>1.7.8.0</version>
+        <version>1.7.8.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil-v1_17_R1_P0/pom.xml
+++ b/nmsutil-v1_17_R1_P0/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>wolfyutilities-parent</artifactId>
         <groupId>com.wolfyscript.wolfyutilities</groupId>
-        <version>1.7.8.0</version>
+        <version>1.7.8.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil-v1_17_R1_P1/pom.xml
+++ b/nmsutil-v1_17_R1_P1/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>wolfyutilities-parent</artifactId>
         <groupId>com.wolfyscript.wolfyutilities</groupId>
-        <version>1.7.8.0</version>
+        <version>1.7.8.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.wolfyscript.wolfyutilities</groupId>
     <artifactId>wolfyutilities-parent</artifactId>
-    <version>1.7.8.0</version>
+    <version>1.7.8.1</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/wolfyutilities/pom.xml
+++ b/wolfyutilities/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <artifactId>wolfyutilities-parent</artifactId>
         <groupId>com.wolfyscript.wolfyutilities</groupId>
-        <version>1.7.8.0</version>
+        <version>1.7.8.1</version>
     </parent>
     <dependencies>
         <dependency>


### PR DESCRIPTION
This fixes issues regarding CustomItems not correctly loading old MetaSettings from config.
Also some changes were made to the way the data is converted:
If it is an old config without any `advanced` setting, or you set `advanced` to true it will try to convert the checks. Each check that is not set to `IGNORE` or `EXACT` will be kept.

In you haven't changed the value of `advanced` all the checks will be cleared and will only include a single check (The CustomItemTag check).

Fixes WolfyScript/CustomCrafting-Wiki#73 - Recipes using custom items not working