### PR TITLE
Fixed - DependenciesLoadedEvent is never called if no integration exists

### DIFF
--- a/core/src/main/java/me/wolfyscript/utilities/compatibility/Plugins.java
+++ b/core/src/main/java/me/wolfyscript/utilities/compatibility/Plugins.java
@@ -122,4 +122,11 @@ public interface Plugins {
      */
     Collection<PluginIntegration> getPluginIntegrations();
 
+    /**
+     * Gets if all PluginIntegrations are loaded.
+     *
+     * @return True if all integrations are done loading or there is nothing to load; else false.
+     */
+    boolean isDoneLoading();
+
 }

--- a/core/src/main/java/me/wolfyscript/utilities/compatibility/PluginsImpl.java
+++ b/core/src/main/java/me/wolfyscript/utilities/compatibility/PluginsImpl.java
@@ -46,6 +46,7 @@ final class PluginsImpl implements Plugins, Listener {
     private final WolfyUtilCore core;
     private final Map<String, PluginIntegrationAbstract> pluginIntegrations = new HashMap<>();
     private final Map<String, Class<? extends PluginIntegrationAbstract>> pluginIntegrationClasses = new HashMap<>();
+    private boolean doneLoading = false;
 
     PluginsImpl(WolfyUtilCore core) {
         this.core = core;
@@ -86,9 +87,11 @@ final class PluginsImpl implements Plugins, Listener {
             pluginIntegrationClasses.forEach(this::createPluginIntegration);
             if (pluginIntegrations.isEmpty()) {
                 core.getLogger().info(" - No integrations created.");
+
             }
         } else {
             core.getLogger().info(" - No integrations found for available plugins");
+            doneLoading = true;
         }
     }
 
@@ -122,6 +125,7 @@ final class PluginsImpl implements Plugins, Listener {
         int availableIntegrations = pluginIntegrationClasses.size();
         long enabledIntegrations = pluginIntegrations.values().stream().filter(PluginIntegrationAbstract::isDoneLoading).count();
         if (availableIntegrations == enabledIntegrations) {
+            doneLoading = true;
             Bukkit.getScheduler().runTaskLater(core, () -> {
                 core.getLogger().info("All dependencies are loaded. Calling the DependenciesLoadedEvent to notify other plugins!");
                 Bukkit.getPluginManager().callEvent(new DependenciesLoadedEvent(core));
@@ -261,4 +265,8 @@ final class PluginsImpl implements Plugins, Listener {
         return Collections.unmodifiableCollection(pluginIntegrations.values());
     }
 
+    @Override
+    public boolean isDoneLoading() {
+        return doneLoading;
+    }
 }


### PR DESCRIPTION
If no integrations are available other plugins have no idea when to load the data, as the event will never be called.
For that there is a new Plugins#isDoneLoading method, that will return if the data is ready.