### PR TITLE
Improved ArmorEquipEvent

### DIFF
--- a/core/src/main/java/me/wolfyscript/utilities/util/events/ArmorEquipEvent.java
+++ b/core/src/main/java/me/wolfyscript/utilities/util/events/ArmorEquipEvent.java
@@ -197,11 +197,11 @@ public class ArmorEquipEvent extends PlayerEvent implements Cancellable {
          */
         DISPENSER,
         /**
-         * TODO: When an armor piece is removed due to it losing all durability.
+         * When an armor piece is removed due to it losing all durability.
          */
         BROKE,
         /**
-         * TODO: When you die causing all armor to unequip
+         * When you die causing all armor to unequip
          */
         DEATH,
         /**

--- a/core/src/main/java/me/wolfyscript/utilities/util/events/ArmorEquipEvent.java
+++ b/core/src/main/java/me/wolfyscript/utilities/util/events/ArmorEquipEvent.java
@@ -193,7 +193,7 @@ public class ArmorEquipEvent extends PlayerEvent implements Cancellable {
          */
         HOTBAR_SWAP,
         /**
-         * TODO: When in range of a dispenser that shoots an armor piece to equip.
+         * When in range of a dispenser that shoots an armor piece to equip.
          */
         DISPENSER,
         /**

--- a/core/src/main/java/me/wolfyscript/utilities/util/events/ArmorEquipEvent.java
+++ b/core/src/main/java/me/wolfyscript/utilities/util/events/ArmorEquipEvent.java
@@ -28,6 +28,13 @@ import org.bukkit.event.HandlerList;
 import org.bukkit.event.player.PlayerEvent;
 import org.bukkit.inventory.ItemStack;
 
+/**
+ * This event is called whenever armor is equipped or unequipped.<br>
+ *
+ * The {@link EquipMethod} shows how the item was equipped/unequipped.<br>
+ * Cancelling the event will prevent the current action.<br>
+ * Cancelling an event with the {@link EquipMethod#DEATH} method has no affect!<br>
+ */
 public class ArmorEquipEvent extends PlayerEvent implements Cancellable {
 
     private static final HandlerList handlers = new HandlerList();

--- a/wolfyutilities/src/main/java/me/wolfyscript/utilities/main/WUPlugin.java
+++ b/wolfyutilities/src/main/java/me/wolfyscript/utilities/main/WUPlugin.java
@@ -81,10 +81,8 @@ public final class WUPlugin extends WolfyUtilCore {
     private final Console console;
     private Metrics metrics;
     private WUConfig config;
-
     private final MessageHandler messageHandler;
     private final MessageFactory messageFactory;
-
     private final CompatibilityManagerImpl compatibilityManager;
 
     public WUPlugin() {

--- a/wolfyutilities/src/main/java/me/wolfyscript/utilities/main/WUPlugin.java
+++ b/wolfyutilities/src/main/java/me/wolfyscript/utilities/main/WUPlugin.java
@@ -223,7 +223,7 @@ public final class WUPlugin extends WolfyUtilCore {
         Bukkit.getPluginManager().registerEvents(new CustomDurabilityListener(this), this);
         Bukkit.getPluginManager().registerEvents(new CustomParticleListener(), this);
         Bukkit.getPluginManager().registerEvents(new BlockListener(), this);
-        Bukkit.getPluginManager().registerEvents(new EquipListener(), this);
+        Bukkit.getPluginManager().registerEvents(new EquipListener(this), this);
         Bukkit.getPluginManager().registerEvents(new PlayerListener(), this);
         Bukkit.getPluginManager().registerEvents(new GUIInventoryListener(), this);
     }

--- a/wolfyutilities/src/main/java/me/wolfyscript/utilities/main/listeners/BlockListener.java
+++ b/wolfyutilities/src/main/java/me/wolfyscript/utilities/main/listeners/BlockListener.java
@@ -122,7 +122,7 @@ public class BlockListener implements Listener {
     }
 
     /*
-    Called when liquid flows or when an Dragon Egg teleports.
+    Called when liquid flows or when a Dragon Egg teleports.
     This Listener only listens for the Dragon Egg
     */
     @EventHandler(ignoreCancelled = true)
@@ -135,11 +135,10 @@ public class BlockListener implements Listener {
         }
     }
 
-    /*
+    /**
      * Piston Events to make sure the position of CustomItems is updated correctly.
      *
      */
-
     @EventHandler(ignoreCancelled = true)
     public void onPistonExtend(BlockPistonExtendEvent event) {
         updatePistonBlocks(event.getBlocks(), event.getDirection());
@@ -206,8 +205,19 @@ public class BlockListener implements Listener {
 
     }
 
+    @EventHandler
+    public void onBlockPhysics(BlockPhysicsEvent event) {
+        var block = event.getBlock();
+        if (event.getChangedType().equals(Material.AIR)) {
+            var storedItem = WorldUtils.getWorldCustomItemStore().getCustomItem(block.getLocation());
+            if (storedItem != null) {
+                WorldUtils.getWorldCustomItemStore().remove(block.getLocation());
+            }
+        }
+    }
+
     /**
-     * Update the CustomItem when it is placed by an Player
+     * Update the CustomItem when it is placed by a Player
      */
     @EventHandler(ignoreCancelled = true, priority = EventPriority.HIGH)
     public void onBlockPlace(BlockPlaceEvent event) {

--- a/wolfyutilities/src/main/java/me/wolfyscript/utilities/main/listeners/EquipListener.java
+++ b/wolfyutilities/src/main/java/me/wolfyscript/utilities/main/listeners/EquipListener.java
@@ -176,11 +176,12 @@ public class EquipListener implements Listener {
         Player player = event.getEntity();
         if (!event.getKeepInventory()) {
             var armorContents = player.getInventory().getArmorContents();
+            var armorTypes = ArmorType.values();
             for (int i = 0; i < armorContents.length; i++) {
                 ItemStack stack = armorContents[i];
                 if (!ItemUtils.isAirOrNull(stack)) {
                     var customItem = CustomItem.getByItemStack(stack);
-                    ArmorType type = ArmorType.values()[i];
+                    ArmorType type = armorTypes[armorContents.length - 1 - i];
                     EventFactory.createArmorEquipEvent(player, ArmorEquipEvent.EquipMethod.DEATH, type, stack, null, customItem, null);
                 }
             }
@@ -206,7 +207,7 @@ public class EquipListener implements Listener {
         }
     }
 
-    @EventHandler
+    @EventHandler(ignoreCancelled = true)
     public void onDispenseVanillaArmor(BlockDispenseArmorEvent event) {
         ArmorType armorType = ArmorType.matchType(event.getItem());
         if (armorType != null) {
@@ -230,7 +231,7 @@ public class EquipListener implements Listener {
         }
     }
 
-    @EventHandler
+    @EventHandler(ignoreCancelled = true)
     public void onDispenseCustomArmor(BlockDispenseEvent event) {
         ItemStack item = event.getItem();
         CustomItem customItem = CustomItem.getByItemStack(item);

--- a/wolfyutilities/src/main/java/me/wolfyscript/utilities/main/listeners/EquipListener.java
+++ b/wolfyutilities/src/main/java/me/wolfyscript/utilities/main/listeners/EquipListener.java
@@ -207,6 +207,9 @@ public class EquipListener implements Listener {
         }
     }
 
+    /**
+     * Manages the vanilla armor and blocks it in case a custom item exists that disallows the vanilla equipment behaviour, or the event is cancelled.
+     */
     @EventHandler(ignoreCancelled = true)
     public void onDispenseVanillaArmor(BlockDispenseArmorEvent event) {
         ArmorType armorType = ArmorType.matchType(event.getItem());
@@ -231,6 +234,9 @@ public class EquipListener implements Listener {
         }
     }
 
+    /**
+     * This event manages custom items that are not actually armor, but have custom equipment settings.
+     */
     @EventHandler(ignoreCancelled = true)
     public void onDispenseCustomArmor(BlockDispenseEvent event) {
         ItemStack item = event.getItem();
@@ -264,14 +270,6 @@ public class EquipListener implements Listener {
                 }
             }
         }
-    }
-
-    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
-    public void inventoryDrag(InventoryDragEvent event) {
-        // getType() seems to always be even.
-        // Old Cursor gives the item you are equipping
-        // Raw slot is the ArmorType slot
-        // Can't replace armor using this method making getCursor() useless.
     }
 
     @EventHandler

--- a/wolfyutilities/src/main/java/me/wolfyscript/utilities/main/listeners/EquipListener.java
+++ b/wolfyutilities/src/main/java/me/wolfyscript/utilities/main/listeners/EquipListener.java
@@ -61,14 +61,10 @@ public class EquipListener implements Listener {
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onClickInventory(InventoryClickEvent event) {
-        if (event.getClick().isCreativeAction()
-                || event.getAction().equals(InventoryAction.NOTHING)
-                || !(event.getWhoClicked() instanceof Player player)
-                || event.getClickedInventory() == null
-                || !event.getClickedInventory().getType().equals(InventoryType.PLAYER)
-                || !event.getView().getTopInventory().getType().equals(InventoryType.PLAYER)) {
+        if (event.getClick().isCreativeAction() || event.getAction().equals(InventoryAction.NOTHING) || !(event.getWhoClicked() instanceof Player player) || event.getClickedInventory() == null) {
             return;
         }
+        if (!event.getInventory().getType().equals(InventoryType.CRAFTING) && !event.getInventory().getType().equals(InventoryType.PLAYER)) return;
         var inv = event.getClickedInventory();
         ItemStack currentItem = event.getCurrentItem();
 

--- a/wolfyutilities/src/main/java/me/wolfyscript/utilities/main/listeners/EquipListener.java
+++ b/wolfyutilities/src/main/java/me/wolfyscript/utilities/main/listeners/EquipListener.java
@@ -49,7 +49,8 @@ public class EquipListener implements Listener {
                 || event.getAction().equals(InventoryAction.NOTHING)
                 || !(event.getWhoClicked() instanceof Player player)
                 || event.getClickedInventory() == null
-                || !event.getClickedInventory().getType().equals(InventoryType.PLAYER)) {
+                || !event.getClickedInventory().getType().equals(InventoryType.PLAYER)
+                || !event.getView().getTopInventory().getType().equals(InventoryType.PLAYER)) {
             return;
         }
         var inv = event.getClickedInventory();

--- a/wolfyutilities/src/main/java/me/wolfyscript/utilities/main/listeners/custom_item/CustomParticleListener.java
+++ b/wolfyutilities/src/main/java/me/wolfyscript/utilities/main/listeners/custom_item/CustomParticleListener.java
@@ -61,7 +61,6 @@ public class CustomParticleListener implements Listener {
     @EventHandler
     public void onDrop(PlayerDropItemEvent event) {
         var player = event.getPlayer();
-        var droppedItem = event.getItemDrop().getItemStack();
         var currentItem = player.getInventory().getItemInMainHand();
 
         if (currentItem.getType().equals(Material.AIR) || currentItem.getAmount() <= 0) {


### PR DESCRIPTION
The ArmorEquipEvent supports armor equipping using Dispenser now.  
Additionally, it will be called on player death and when an item breaks.

The dispenser is also able to equip custom item armor (Or drop the item as normal if the player already has it equipped, or it couldn't find a player).