### PR TITLE
Fixed ParticleContent issues

### DIFF
--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/ParticleContent.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/custom_items/ParticleContent.java
@@ -37,6 +37,7 @@ import java.util.Objects;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonSerialize
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ParticleContent {
 
     private Settings location = null;
@@ -196,7 +197,7 @@ public class ParticleContent {
             return animation;
         }
 
-        @JsonSetter
+        @JsonSetter(nulls = Nulls.SKIP)
         public void setAnimation(ParticleAnimation animation) {
             this.animation = Objects.requireNonNull(animation, "Animation cannot be null!");
         }


### PR DESCRIPTION
The ParticleContent no longer includes null values and will skip them on serialization.
This prevents loading issues when you set the animation to null.