### PR TITLE
Revert to shaded Jackson library

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <artifactId>wolfyutilities-parent</artifactId>
         <groupId>com.wolfyscript.wolfyutilities</groupId>
-        <version>2.16.2.0</version>
+        <version>3.16.0.0</version>
     </parent>
     <build>
         <plugins>

--- a/nmsutil/nmsutil-artifact/pom.xml
+++ b/nmsutil/nmsutil-artifact/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutilities</groupId>
-        <version>2.16.2.0</version>
+        <version>3.16.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/nmsutil-v1_15_R1/pom.xml
+++ b/nmsutil/nmsutil-v1_15_R1/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutilities</groupId>
-        <version>2.16.2.0</version>
+        <version>3.16.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/nmsutil-v1_16_R1/pom.xml
+++ b/nmsutil/nmsutil-v1_16_R1/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutilities</groupId>
-        <version>2.16.2.0</version>
+        <version>3.16.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/nmsutil-v1_16_R2/pom.xml
+++ b/nmsutil/nmsutil-v1_16_R2/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutilities</groupId>
-        <version>2.16.2.0</version>
+        <version>3.16.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/nmsutil-v1_16_R3/pom.xml
+++ b/nmsutil/nmsutil-v1_16_R3/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutilities</groupId>
-        <version>2.16.2.0</version>
+        <version>3.16.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/nmsutil-v1_17_R1_P0/pom.xml
+++ b/nmsutil/nmsutil-v1_17_R1_P0/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutilities</groupId>
-        <version>2.16.2.0</version>
+        <version>3.16.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/nmsutil-v1_17_R1_P1/pom.xml
+++ b/nmsutil/nmsutil-v1_17_R1_P1/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutilities</groupId>
-        <version>2.16.2.0</version>
+        <version>3.16.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/nmsutil-v1_18_R1_P0/pom.xml
+++ b/nmsutil/nmsutil-v1_18_R1_P0/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutilities</groupId>
-        <version>2.16.2.0</version>
+        <version>3.16.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/nmsutil-v1_18_R1_P1/pom.xml
+++ b/nmsutil/nmsutil-v1_18_R1_P1/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutilities</groupId>
-        <version>2.16.2.0</version>
+        <version>3.16.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/pom.xml
+++ b/nmsutil/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>wolfyutilities-parent</artifactId>
         <groupId>com.wolfyscript.wolfyutilities</groupId>
-        <version>2.16.2.0</version>
+        <version>3.16.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/plugin-compatibility-module/itemsadder/pom.xml
+++ b/plugin-compatibility-module/itemsadder/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>plugin-compatibility-module</artifactId>
         <groupId>com.wolfyscript.wolfyutilities</groupId>
-        <version>2.16.2.0</version>
+        <version>3.16.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/plugin-compatibility-module/magic/pom.xml
+++ b/plugin-compatibility-module/magic/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>plugin-compatibility-module</artifactId>
         <groupId>com.wolfyscript.wolfyutilities</groupId>
-        <version>2.16.2.0</version>
+        <version>3.16.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/plugin-compatibility-module/mmoitems/pom.xml
+++ b/plugin-compatibility-module/mmoitems/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>plugin-compatibility-module</artifactId>
         <groupId>com.wolfyscript.wolfyutilities</groupId>
-        <version>2.16.2.0</version>
+        <version>3.16.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/plugin-compatibility-module/mythicmobs/pom.xml
+++ b/plugin-compatibility-module/mythicmobs/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>plugin-compatibility-module</artifactId>
         <groupId>com.wolfyscript.wolfyutilities</groupId>
-        <version>2.16.2.0</version>
+        <version>3.16.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/plugin-compatibility-module/oraxen/pom.xml
+++ b/plugin-compatibility-module/oraxen/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>plugin-compatibility-module</artifactId>
         <groupId>com.wolfyscript.wolfyutilities</groupId>
-        <version>2.16.2.0</version>
+        <version>3.16.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/plugin-compatibility-module/plugin-compatibility-artifact/pom.xml
+++ b/plugin-compatibility-module/plugin-compatibility-artifact/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>plugin-compatibility-module</artifactId>
         <groupId>com.wolfyscript.wolfyutilities</groupId>
-        <version>2.16.2.0</version>
+        <version>3.16.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/plugin-compatibility-module/pom.xml
+++ b/plugin-compatibility-module/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>wolfyutilities-parent</artifactId>
         <groupId>com.wolfyscript.wolfyutilities</groupId>
-        <version>2.16.2.0</version>
+        <version>3.16.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.wolfyscript.wolfyutilities</groupId>
     <artifactId>wolfyutilities-parent</artifactId>
-    <version>2.16.2.0</version>
+    <version>3.16.0.0</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.13.0</version>
+            <version>2.13.1</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/wolfyutilities/pom.xml
+++ b/wolfyutilities/pom.xml
@@ -39,12 +39,6 @@
             <version>2.2.1</version>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>2.13.0</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
             <groupId>org.reflections</groupId>
             <artifactId>reflections</artifactId>
             <version>0.10.2</version>

--- a/wolfyutilities/pom.xml
+++ b/wolfyutilities/pom.xml
@@ -44,6 +44,12 @@
             <version>0.10.2</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.13.1</version>
+            <scope>compile</scope>
+        </dependency>
         <!-- NMS module -->
         <dependency>
             <groupId>${project.groupId}</groupId>
@@ -107,6 +113,10 @@
                                     <pattern>javassist</pattern>
                                     <shadedPattern>me.wolfyscript.lib.javassist</shadedPattern>
                                 </relocation>
+                                <relocation>
+                                    <pattern>com.fasterxml.jackson</pattern>
+                                    <shadedPattern>me.wolfyscript.lib.com.fasterxml.jackson</shadedPattern>
+                                </relocation>
                             </relocations>
                             <shadeSourcesContent>true</shadeSourcesContent>
                             <shadedArtifactAttached>false</shadedArtifactAttached>
@@ -114,6 +124,7 @@
                                 <includes>
                                     <include>com.wolfyscript.wolfyutilities</include>
                                     <include>org.bstats</include>
+                                    <include>com.fasterxml.jackson.core</include>
                                     <include>org.reflections</include>
                                     <include>org.javassist</include>
                                 </includes>

--- a/wolfyutilities/pom.xml
+++ b/wolfyutilities/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <artifactId>wolfyutilities-parent</artifactId>
         <groupId>com.wolfyscript.wolfyutilities</groupId>
-        <version>2.16.2.0</version>
+        <version>3.16.0.0</version>
     </parent>
     <dependencies>
         <dependency>

--- a/wolfyutilities/src/main/resources/plugin.yml
+++ b/wolfyutilities/src/main/resources/plugin.yml
@@ -5,7 +5,6 @@ author: WolfyScript
 main: me.wolfyscript.utilities.main.WUPlugin
 
 loadbefore:
-  - CustomCrafting
   - ChatColor
   - ChatColor2
   - StackableItems
@@ -24,9 +23,6 @@ softdepend:
   - Oraxen
   - ItemsAdder
   - ExecutableItems
-
-libraries:
-  - com.fasterxml.jackson.core:jackson-databind:2.13.0
 
 commands:
   wolfyutils:


### PR DESCRIPTION
The library feature from Spigot just doesn't work on 1.16.5.
![spigots lie](https://cdn.discordapp.com/attachments/925836871521677362/926101592787275836/unknown.png)

Additionally there are still lots of plugins out there, that do not relocate their libraries, which conflicts with the spigots library loader if it does work in 1.17.x - 18.x.

This update removes the libraries feature usage and shades jackson back into the jar and relocates it to `me.wolfyscript.lib.com.fasterxml`