### PR TITLE
Updateable GUI Titles & PlaceholderAPI support

### DIFF
--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/GuiUpdate.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/GuiUpdate.java
@@ -66,7 +66,7 @@ public class GuiUpdate<C extends CustomCache> {
             String title = guiWindow.onUpdateTitle(guiWindow.getInventoryName(), inventory, guiHandler, guiWindow);
             var desc = wolfyUtilities.getCore().getDescription();
             title = title.replace("%plugin.version%", desc.getVersion()).replace("%plugin.author%", desc.getAuthors().toString()).replace("%plugin.name%", desc.getName());
-            PlaceholderAPIIntegration integration = wolfyUtilities.getCore().getCompatibilityManager().getPlugins().getIntegration("PlaceHolderAPI", PlaceholderAPIIntegration.class);
+            PlaceholderAPIIntegration integration = wolfyUtilities.getCore().getCompatibilityManager().getPlugins().getIntegration("PlaceholderAPI", PlaceholderAPIIntegration.class);
             if (integration != null) {
                 title = integration.setPlaceholders(player, integration.setBracketPlaceholders(player, title));
             }

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/GuiUpdate.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/GuiUpdate.java
@@ -23,6 +23,7 @@ import me.wolfyscript.utilities.api.inventory.gui.button.Button;
 import me.wolfyscript.utilities.api.inventory.gui.cache.CustomCache;
 import me.wolfyscript.utilities.api.nms.inventory.GUIInventory;
 import me.wolfyscript.utilities.util.NamespacedKey;
+import me.wolfyscript.utilities.util.chat.ChatColor;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryInteractEvent;
@@ -61,8 +62,11 @@ public class GuiUpdate<C extends CustomCache> {
         if (inventory != null) {
             this.inventory = inventory;
         } else {
-            String guiName = guiWindow.getInventoryName();
-            guiName = guiName.replace("%plugin.version%", wolfyUtilities.getPlugin().getDescription().getVersion()).replace("%plugin.author%", wolfyUtilities.getPlugin().getDescription().getAuthors().toString()).replace("%plugin.name%", wolfyUtilities.getPlugin().getDescription().getName());
+            String guiName = guiWindow.onUpdateTitle(guiWindow.getInventoryName(), inventory, guiHandler, guiWindow);
+            var desc = wolfyUtilities.getCore().getDescription();
+            guiName = guiName.replace("%plugin.version%", desc.getVersion()).replace("%plugin.author%", desc.getAuthors().toString()).replace("%plugin.name%", desc.getName());
+            //TODO: PlaceHolderAPI integration
+            guiName = ChatColor.convert(guiName);
             if (guiWindow.getInventoryType() == null) {
                 this.inventory = wolfyUtilities.getNmsUtil().getInventoryUtil().createGUIInventory(guiHandler, guiWindow, guiWindow.getSize(), guiName);
             } else {

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/GuiUpdate.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/GuiUpdate.java
@@ -22,6 +22,7 @@ import me.wolfyscript.utilities.api.WolfyUtilities;
 import me.wolfyscript.utilities.api.inventory.gui.button.Button;
 import me.wolfyscript.utilities.api.inventory.gui.cache.CustomCache;
 import me.wolfyscript.utilities.api.nms.inventory.GUIInventory;
+import me.wolfyscript.utilities.compatibility.plugins.PlaceholderAPIIntegration;
 import me.wolfyscript.utilities.util.NamespacedKey;
 import me.wolfyscript.utilities.util.chat.ChatColor;
 import org.bukkit.Bukkit;
@@ -62,15 +63,18 @@ public class GuiUpdate<C extends CustomCache> {
         if (inventory != null) {
             this.inventory = inventory;
         } else {
-            String guiName = guiWindow.onUpdateTitle(guiWindow.getInventoryName(), inventory, guiHandler, guiWindow);
+            String title = guiWindow.onUpdateTitle(guiWindow.getInventoryName(), inventory, guiHandler, guiWindow);
             var desc = wolfyUtilities.getCore().getDescription();
-            guiName = guiName.replace("%plugin.version%", desc.getVersion()).replace("%plugin.author%", desc.getAuthors().toString()).replace("%plugin.name%", desc.getName());
-            //TODO: PlaceHolderAPI integration
-            guiName = ChatColor.convert(guiName);
+            title = title.replace("%plugin.version%", desc.getVersion()).replace("%plugin.author%", desc.getAuthors().toString()).replace("%plugin.name%", desc.getName());
+            PlaceholderAPIIntegration integration = wolfyUtilities.getCore().getCompatibilityManager().getPlugins().getIntegration("PlaceHolderAPI", PlaceholderAPIIntegration.class);
+            if (integration != null) {
+                title = integration.setPlaceholders(player, integration.setBracketPlaceholders(player, title));
+            }
+            title = ChatColor.convert(title);
             if (guiWindow.getInventoryType() == null) {
-                this.inventory = wolfyUtilities.getNmsUtil().getInventoryUtil().createGUIInventory(guiHandler, guiWindow, guiWindow.getSize(), guiName);
+                this.inventory = wolfyUtilities.getNmsUtil().getInventoryUtil().createGUIInventory(guiHandler, guiWindow, guiWindow.getSize(), title);
             } else {
-                this.inventory = wolfyUtilities.getNmsUtil().getInventoryUtil().createGUIInventory(guiHandler, guiWindow, guiWindow.getInventoryType(), guiName);
+                this.inventory = wolfyUtilities.getNmsUtil().getInventoryUtil().createGUIInventory(guiHandler, guiWindow, guiWindow.getInventoryType(), title);
             }
         }
     }

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/GuiUpdate.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/GuiUpdate.java
@@ -63,7 +63,7 @@ public class GuiUpdate<C extends CustomCache> {
         if (inventory != null) {
             this.inventory = inventory;
         } else {
-            String title = guiWindow.onUpdateTitle(guiWindow.getInventoryName(), inventory, guiHandler, guiWindow);
+            String title = guiWindow.onUpdateTitle(guiWindow.getInventoryName(), null, guiHandler);
             var desc = wolfyUtilities.getCore().getDescription();
             title = title.replace("%plugin.version%", desc.getVersion()).replace("%plugin.author%", desc.getAuthors().toString()).replace("%plugin.name%", desc.getName());
             PlaceholderAPIIntegration integration = wolfyUtilities.getCore().getCompatibilityManager().getPlugins().getIntegration("PlaceholderAPI", PlaceholderAPIIntegration.class);

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/GuiWindow.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/GuiWindow.java
@@ -152,7 +152,18 @@ public abstract class GuiWindow<C extends CustomCache> implements Listener {
      */
     public abstract void onUpdateSync(GuiUpdate<C> update);
 
-    public String onUpdateTitle(String originalTitle, GUIInventory<C> inventory, GuiHandler<C> guiHandler, GuiWindow<C> guiWindow) {
+    /**
+     * Called each time the title of the window is updated.<br>
+     * By default, that only happens once, when the player opens the inventory.<br>
+     * Using {@link #setTitleUpdateDelay(int)} and {@link #setTitleUpdatePeriod(int)} you can set the frequency at which the title is updated.<br>
+     * When enabled this will be called every specified period.
+     *
+     * @param originalTitle The original title from the language file.
+     * @param inventory The inventory instance, which title is updated. Null when the inventory is opened for the first time!
+     * @param guiHandler The handler that the inventory belongs to.
+     * @return The new modified title. Color codes using & will be converted.
+     */
+    public String onUpdateTitle(String originalTitle, @Nullable GUIInventory<C> inventory, GuiHandler<C> guiHandler) {
         return originalTitle;
     }
 
@@ -220,7 +231,7 @@ public abstract class GuiWindow<C extends CustomCache> implements Listener {
                     guiHandler.setWindowUpdateTask(Bukkit.getScheduler().runTaskTimer(wolfyUtilities.getPlugin(), () -> {
                         var player = guiHandler.getPlayer();
                         if (player != null) {
-                            String title = onUpdateTitle(getInventoryName(), inv, guiHandler, this);
+                            String title = onUpdateTitle(getInventoryName(), inv, guiHandler);
                             PlaceholderAPIIntegration integration = wolfyUtilities.getCore().getCompatibilityManager().getPlugins().getIntegration("PlaceholderAPI", PlaceholderAPIIntegration.class);
                             if (integration != null) {
                                 title = integration.setPlaceholders(player, integration.setBracketPlaceholders(player, title));

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/GuiWindow.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/GuiWindow.java
@@ -24,6 +24,7 @@ import me.wolfyscript.utilities.api.inventory.gui.button.Button;
 import me.wolfyscript.utilities.api.inventory.gui.button.buttons.ItemInputButton;
 import me.wolfyscript.utilities.api.inventory.gui.cache.CustomCache;
 import me.wolfyscript.utilities.api.nms.inventory.GUIInventory;
+import me.wolfyscript.utilities.compatibility.plugins.PlaceholderAPIIntegration;
 import me.wolfyscript.utilities.util.NamespacedKey;
 import me.wolfyscript.utilities.util.Pair;
 import me.wolfyscript.utilities.util.chat.ChatColor;
@@ -219,9 +220,12 @@ public abstract class GuiWindow<C extends CustomCache> implements Listener {
                     guiHandler.setWindowUpdateTask(Bukkit.getScheduler().runTaskTimer(wolfyUtilities.getPlugin(), () -> {
                         var player = guiHandler.getPlayer();
                         if (player != null) {
-                            String title = ChatColor.convert(onUpdateTitle(getInventoryName(), inv, guiHandler, this));
-                            //TODO: PlaceHolderAPI integration
-                            InventoryUpdate.updateInventory(wolfyUtilities.getCore(), player, title);
+                            String title = onUpdateTitle(getInventoryName(), inv, guiHandler, this);
+                            PlaceholderAPIIntegration integration = wolfyUtilities.getCore().getCompatibilityManager().getPlugins().getIntegration("PlaceHolderAPI", PlaceholderAPIIntegration.class);
+                            if (integration != null) {
+                                title = integration.setPlaceholders(player, integration.setBracketPlaceholders(player, title));
+                            }
+                            InventoryUpdate.updateInventory(wolfyUtilities.getCore(), player, ChatColor.convert(title));
                         }
                     }, titleUpdateDelay, titleUpdatePeriod));
                 }

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/GuiWindow.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/GuiWindow.java
@@ -221,7 +221,7 @@ public abstract class GuiWindow<C extends CustomCache> implements Listener {
                         var player = guiHandler.getPlayer();
                         if (player != null) {
                             String title = onUpdateTitle(getInventoryName(), inv, guiHandler, this);
-                            PlaceholderAPIIntegration integration = wolfyUtilities.getCore().getCompatibilityManager().getPlugins().getIntegration("PlaceHolderAPI", PlaceholderAPIIntegration.class);
+                            PlaceholderAPIIntegration integration = wolfyUtilities.getCore().getCompatibilityManager().getPlugins().getIntegration("PlaceholderAPI", PlaceholderAPIIntegration.class);
                             if (integration != null) {
                                 title = integration.setPlaceholders(player, integration.setBracketPlaceholders(player, title));
                             }

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/GuiWindow.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/GuiWindow.java
@@ -148,6 +148,10 @@ public abstract class GuiWindow<C extends CustomCache> implements Listener {
      */
     public abstract void onUpdateSync(GuiUpdate<C> update);
 
+    public String onUpdateTitle(String originalTitle, GUIInventory<C> inventory, GuiHandler<C> guiHandler, GuiWindow<C> guiWindow) {
+        return originalTitle;
+    }
+
     /**
      * This method is called after the {@link #onUpdateSync(GuiUpdate)} is done.
      * It will be run by the scheduler Async, so be careful with using Bukkit methods!

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/GuiWindow.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/GuiWindow.java
@@ -35,6 +35,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryInteractEvent;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.inventory.InventoryView;
+import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
@@ -433,18 +434,41 @@ public abstract class GuiWindow<C extends CustomCache> implements Listener {
         this.forceSyncUpdate = forceSyncUpdate;
     }
 
+    /**
+     * Sets the initial delay (in ticks), after which the title is updated.
+     *
+     * @param titleUpdateDelay The initial delay in ticks.
+     */
     public void setTitleUpdateDelay(int titleUpdateDelay) {
         this.titleUpdateDelay = titleUpdateDelay;
     }
 
+    /**
+     * Gets the initial delay the update task waits after the inventory was opened.
+     *
+     * @return The initial delay in ticks.
+     */
     public int getTitleUpdateDelay() {
         return titleUpdateDelay;
     }
 
+    /**
+     * Sets the period delay (in ticks). The title is updated each period.<br>
+     * <b>This can cause flickering of the inventory! The shorter the period, the more noticeable!</b><br>
+     * A period delay of -1 will completely disable the update task.
+     *
+     * @param titleUpdatePeriod The delay between each title update in ticks. Default: -1 = disabled.
+     */
     public void setTitleUpdatePeriod(int titleUpdatePeriod) {
         this.titleUpdatePeriod = titleUpdatePeriod;
     }
 
+    /**
+     * Gets the current period delay between each title update.<br>
+     * A period delay of -1 means that the update task is disabled.
+     *
+     * @return The delay between each title update. Default: -1
+     */
     public int getTitleUpdatePeriod() {
         return titleUpdatePeriod;
     }

--- a/core/src/main/java/me/wolfyscript/utilities/compatibility/plugins/PlaceholderAPIIntegration.java
+++ b/core/src/main/java/me/wolfyscript/utilities/compatibility/plugins/PlaceholderAPIIntegration.java
@@ -1,0 +1,66 @@
+/*
+ *       WolfyUtilities, APIs and Utilities for Minecraft Spigot plugins
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package me.wolfyscript.utilities.compatibility.plugins;
+
+import me.wolfyscript.utilities.compatibility.PluginIntegration;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+public interface PlaceholderAPIIntegration extends PluginIntegration {
+
+    @NotNull String setPlaceholders(OfflinePlayer player, @NotNull String text);
+
+    @NotNull List<String> setPlaceholders(OfflinePlayer player, @NotNull List<String> text);
+
+    @NotNull String setPlaceholders(Player player, @NotNull String text);
+
+    @NotNull List<String> setPlaceholders(Player player, @NotNull List<String> text);
+
+    @NotNull String setBracketPlaceholders(OfflinePlayer player, @NotNull String text);
+
+    @NotNull List<String> setBracketPlaceholders(OfflinePlayer player, @NotNull List<String> text);
+
+    String setBracketPlaceholders(Player player, @NotNull String text);
+
+    List<String> setBracketPlaceholders(Player player, @NotNull List<String> text);
+
+    String setRelationalPlaceholders(Player one, Player two, String text);
+
+    List<String> setRelationalPlaceholders(Player one, Player two, List<String> text);
+
+    boolean isRegistered(@NotNull String identifier);
+
+    Set<String> getRegisteredIdentifiers();
+
+    Pattern getPlaceholderPattern();
+
+    Pattern getBracketPlaceholderPattern();
+
+    Pattern getRelationalPlaceholderPattern();
+
+    boolean containsPlaceholders(String text);
+
+    boolean containsBracketPlaceholders(String text);
+
+}

--- a/core/src/main/java/me/wolfyscript/utilities/util/reflection/InventoryUpdate.java
+++ b/core/src/main/java/me/wolfyscript/utilities/util/reflection/InventoryUpdate.java
@@ -1,0 +1,275 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021 Matsubara
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+ * PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+ * FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package me.wolfyscript.utilities.util.reflection;
+
+import me.wolfyscript.utilities.util.Reflection;
+import me.wolfyscript.utilities.util.version.ServerVersion;
+import org.apache.commons.lang.Validate;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.inventory.InventoryView;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.util.Arrays;
+
+/**
+ * A utility class to update the inventory of a player.
+ * This is useful to change the title of an inventory.
+ */
+public final class InventoryUpdate {
+
+    // Classes.
+    private final static Class<?> CRAFT_PLAYER_CLASS;
+    private final static Class<?> CHAT_MESSAGE_CLASS;
+    private final static Class<?> PACKET_PLAY_OUT_OPEN_WINDOW_CLASS;
+    private final static Class<?> I_CHAT_BASE_COMPONENT_CLASS;
+    private final static Class<?> CONTAINERS_CLASS;
+    private final static Class<?> ENTITY_PLAYER_CLASS;
+    private final static Class<?> CONTAINER_CLASS;
+
+    // Methods.
+    private final static MethodHandle getHandle;
+    private final static MethodHandle getBukkitView;
+
+    // Constructors.
+    private static Constructor<?> chatMessageConstructor;
+    private static Constructor<?> packetPlayOutOpenWindowConstructor;
+
+    // Fields.
+    private static Field activeContainerField;
+    private static Field windowIdField;
+
+    static {
+        // Initialize classes.
+        CRAFT_PLAYER_CLASS = Reflection.getOBC("entity.CraftPlayer");
+        CHAT_MESSAGE_CLASS = Reflection.getNMS("network.chat", "ChatMessage");
+        PACKET_PLAY_OUT_OPEN_WINDOW_CLASS = Reflection.getNMS("network.protocol.game", "PacketPlayOutOpenWindow");
+        I_CHAT_BASE_COMPONENT_CLASS = Reflection.getNMS("network.chat", "IChatBaseComponent");
+        // Check if we use containers, otherwise, can throw errors on older versions.
+        CONTAINERS_CLASS = Reflection.getNMS("world.inventory", "Containers");
+        ENTITY_PLAYER_CLASS = Reflection.getNMS("server.level", "EntityPlayer");
+        CONTAINER_CLASS = Reflection.getNMS("world.inventory", "Container");
+
+        MethodHandle handle = null, bukkitView = null;
+
+        try {
+            int version = ServerVersion.getVersion().getMinor();
+            MethodHandles.Lookup lookup = MethodHandles.lookup();
+
+            // Initialize methods.
+            handle = lookup.findVirtual(CRAFT_PLAYER_CLASS, "getHandle", MethodType.methodType(ENTITY_PLAYER_CLASS));
+            bukkitView = lookup.findVirtual(CONTAINER_CLASS, "getBukkitView", MethodType.methodType(InventoryView.class));
+
+            // Initialize constructors.
+            chatMessageConstructor = CHAT_MESSAGE_CLASS.getConstructor(String.class, Object[].class);
+            packetPlayOutOpenWindowConstructor = PACKET_PLAY_OUT_OPEN_WINDOW_CLASS.getConstructor(int.class, CONTAINERS_CLASS, I_CHAT_BASE_COMPONENT_CLASS);
+
+            // Initialize fields.
+            activeContainerField = (version == 17) ?
+                    ENTITY_PLAYER_CLASS.getField("bV") : (version == 18) ?
+                    ENTITY_PLAYER_CLASS.getField("bW") :
+                    ENTITY_PLAYER_CLASS.getField("activeContainer");
+            windowIdField = (version > 16) ? CONTAINER_CLASS.getField("j") : CONTAINER_CLASS.getField("windowId");
+        } catch (ReflectiveOperationException exception) {
+            exception.printStackTrace();
+        }
+        getHandle = handle;
+        getBukkitView = bukkitView;
+    }
+
+    /**
+     * Update the player inventory, so you can change the title.
+     *
+     * @param player   whose inventory will be updated.
+     * @param newTitle the new title for the inventory.
+     */
+    public static void updateInventory(JavaPlugin plugin, Player player, String newTitle) {
+        Validate.notNull(player, "Cannot update inventory to null player.");
+        try {
+            // Get EntityPlayer from CraftPlayer.
+            Object craftPlayer = CRAFT_PLAYER_CLASS.cast(player);
+            Object entityPlayer = getHandle.invoke(craftPlayer);
+
+            if (newTitle != null && newTitle.length() > 32) {
+                newTitle = newTitle.substring(0, 32);
+            }
+            // Create new title.
+            Object title = chatMessageConstructor.newInstance(newTitle != null ? newTitle : "", new Object[]{});
+            // Get activeContainer from EntityPlayer.
+            Object activeContainer = activeContainerField.get(entityPlayer);
+            // Get windowId from activeContainer.
+            Integer windowId = (Integer) windowIdField.get(activeContainer);
+            // Get InventoryView from activeContainer.
+            Object bukkitView = getBukkitView.invoke(activeContainer);
+            if (!(bukkitView instanceof InventoryView view)) return;
+            InventoryType type = view.getTopInventory().getType();
+
+            // You can't reopen crafting, creative and player inventory.
+            if (Arrays.asList("CRAFTING", "CREATIVE", "PLAYER").contains(type.name())) return;
+
+            int size = view.getTopInventory().getSize();
+
+            // Get container, check is not null.
+            Containers container = Containers.getType(type, size);
+            if (container == null) return;
+
+            // If the container was added in a newer versions than the current, return.
+            if (container.getContainerVersion() > ServerVersion.getVersion().getMinor()) {
+                Bukkit.getLogger().warning(String.format(
+                        "[%s] This container doesn't work on your current version.",
+                        plugin.getDescription().getName()));
+                return;
+            }
+            Object object = container.getObject();
+            // Create packet.
+            Object packet = packetPlayOutOpenWindowConstructor.newInstance(windowId, object, title);
+
+            // Send packet sync.
+            Reflection.sendPacket(player, packet);
+
+            // Update inventory.
+            player.updateInventory();
+        } catch (Throwable throwable) {
+            throwable.printStackTrace();
+        }
+    }
+
+    /**
+     * An enum class for the necessaries containers.
+     */
+    private enum Containers {
+        GENERIC_9X1(14, "minecraft:chest", "CHEST"),
+        GENERIC_9X2(14, "minecraft:chest", "CHEST"),
+        GENERIC_9X3(14, "minecraft:chest", "CHEST", "ENDER_CHEST", "BARREL"),
+        GENERIC_9X4(14, "minecraft:chest", "CHEST"),
+        GENERIC_9X5(14, "minecraft:chest", "CHEST"),
+        GENERIC_9X6(14, "minecraft:chest", "CHEST"),
+        GENERIC_3X3(14, null, "DISPENSER", "DROPPER"),
+        ANVIL(14, "minecraft:anvil", "ANVIL"),
+        BEACON(14, "minecraft:beacon", "BEACON"),
+        BREWING_STAND(14, "minecraft:brewing_stand", "BREWING"),
+        ENCHANTMENT(14, "minecraft:enchanting_table", "ENCHANTING"),
+        FURNACE(14, "minecraft:furnace", "FURNACE"),
+        HOPPER(14, "minecraft:hopper", "HOPPER"),
+        MERCHANT(14, "minecraft:villager", "MERCHANT"),
+        // For an unknown reason, when updating a shulker box, the size of the inventory get a little bigger.
+        SHULKER_BOX(14, "minecraft:blue_shulker_box", "SHULKER_BOX"),
+
+        // Added in 1.14, so only works with containers.
+        BLAST_FURNACE(14, null, "BLAST_FURNACE"),
+        CRAFTING(14, null, "WORKBENCH"),
+        GRINDSTONE(14, null, "GRINDSTONE"),
+        LECTERN(14, null, "LECTERN"),
+        LOOM(14, null, "LOOM"),
+        SMOKER(14, null, "SMOKER"),
+        // CARTOGRAPHY in 1.14, CARTOGRAPHY_TABLE in 1.15 & 1.16 (container), handle in getObject().
+        CARTOGRAPHY_TABLE(14, null, "CARTOGRAPHY"),
+        STONECUTTER(14, null, "STONECUTTER"),
+
+        // Added in 1.14, functional since 1.16.
+        SMITHING(16, null, "SMITHING");
+
+        private final int containerVersion;
+        private final String minecraftName;
+        private final String[] inventoryTypesNames;
+
+        private final static char[] alphabet = "abcdefghijklmnopqrstuvwxyz".toCharArray();
+
+        Containers(int containerVersion, String minecraftName, String... inventoryTypesNames) {
+            this.containerVersion = containerVersion;
+            this.minecraftName = minecraftName;
+            this.inventoryTypesNames = inventoryTypesNames;
+        }
+
+        /**
+         * Get the container based on the current open inventory of the player.
+         *
+         * @param type type of inventory.
+         * @return the container.
+         */
+        public static Containers getType(InventoryType type, int size) {
+            if (type == InventoryType.CHEST) {
+                return Containers.valueOf("GENERIC_9X" + size / 9);
+            }
+            for (Containers container : Containers.values()) {
+                for (String bukkitName : container.getInventoryTypesNames()) {
+                    if (bukkitName.equalsIgnoreCase(type.toString())) {
+                        return container;
+                    }
+                }
+            }
+            return null;
+        }
+
+        /**
+         * Get the object from the container enum.
+         *
+         * @return a Containers object if 1.14+, otherwise, a String.
+         */
+        public Object getObject() {
+            try {
+                int version = ServerVersion.getVersion().getMinor();
+                String name = (version == 14 && this == CARTOGRAPHY_TABLE) ? "CARTOGRAPHY" : name();
+                // Since 1.17, containers go from "a" to "x".
+                if (version > 16) name = String.valueOf(alphabet[ordinal()]);
+                Field field = CONTAINERS_CLASS.getField(name);
+                return field.get(null);
+            } catch (ReflectiveOperationException exception) {
+                exception.printStackTrace();
+            }
+            return null;
+        }
+
+        /**
+         * Get the version in which the inventory container was added.
+         *
+         * @return the version.
+         */
+        public int getContainerVersion() {
+            return containerVersion;
+        }
+
+        /**
+         * Get the name of the inventory from Minecraft for older versions.
+         *
+         * @return name of the inventory.
+         */
+        public String getMinecraftName() {
+            return minecraftName;
+        }
+
+        /**
+         * Get inventory types names of the inventory.
+         *
+         * @return bukkit names.
+         */
+        public String[] getInventoryTypesNames() {
+            return inventoryTypesNames;
+        }
+    }
+}

--- a/wolfyutilities/pom.xml
+++ b/wolfyutilities/pom.xml
@@ -50,6 +50,12 @@
             <version>2.13.1</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>me.clip</groupId>
+            <artifactId>placeholderapi</artifactId>
+            <version>2.11.1</version>
+            <scope>provided</scope>
+        </dependency>
         <!-- NMS module -->
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/wolfyutilities/src/main/java/me/wolfyscript/utilities/compatibility/plugins/PlaceholderAPIImpl.java
+++ b/wolfyutilities/src/main/java/me/wolfyscript/utilities/compatibility/plugins/PlaceholderAPIImpl.java
@@ -34,7 +34,7 @@ import java.util.regex.Pattern;
 @WUPluginIntegration(pluginName = PlaceholderAPIImpl.PLUGIN_NAME)
 public class PlaceholderAPIImpl extends PluginIntegrationAbstract implements PlaceholderAPIIntegration {
 
-    static final String PLUGIN_NAME = "PlaceHolderAPI";
+    static final String PLUGIN_NAME = "PlaceholderAPI";
 
     /**
      * The main constructor that is called whenever the integration is created.<br>

--- a/wolfyutilities/src/main/java/me/wolfyscript/utilities/compatibility/plugins/PlaceholderAPIImpl.java
+++ b/wolfyutilities/src/main/java/me/wolfyscript/utilities/compatibility/plugins/PlaceholderAPIImpl.java
@@ -1,0 +1,142 @@
+/*
+ *       WolfyUtilities, APIs and Utilities for Minecraft Spigot plugins
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package me.wolfyscript.utilities.compatibility.plugins;
+
+import me.clip.placeholderapi.PlaceholderAPI;
+import me.wolfyscript.utilities.annotations.WUPluginIntegration;
+import me.wolfyscript.utilities.api.WolfyUtilCore;
+import me.wolfyscript.utilities.compatibility.PluginIntegrationAbstract;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+@WUPluginIntegration(pluginName = PlaceholderAPIImpl.PLUGIN_NAME)
+public class PlaceholderAPIImpl extends PluginIntegrationAbstract implements PlaceholderAPIIntegration {
+
+    static final String PLUGIN_NAME = "PlaceHolderAPI";
+
+    /**
+     * The main constructor that is called whenever the integration is created.<br>
+     *
+     * @param core       The WolfyUtilCore.
+     */
+    protected PlaceholderAPIImpl(WolfyUtilCore core) {
+        super(core, PLUGIN_NAME);
+    }
+
+    @Override
+    public void init(Plugin plugin) {
+
+    }
+
+    @Override
+    public boolean hasAsyncLoading() {
+        return false;
+    }
+
+    @Override
+    public @NotNull String setPlaceholders(OfflinePlayer player, @NotNull String text) {
+        return PlaceholderAPI.setPlaceholders(player, text);
+    }
+
+    @Override
+    public @NotNull List<String> setPlaceholders(OfflinePlayer player, @NotNull List<String> text) {
+        return PlaceholderAPI.setPlaceholders(player, text);
+    }
+
+    @Override
+    public @NotNull String setPlaceholders(Player player, @NotNull String text) {
+        return PlaceholderAPI.setPlaceholders(player, text);
+    }
+
+    @Override
+    public @NotNull List<String> setPlaceholders(Player player, @NotNull List<String> text) {
+        return PlaceholderAPI.setPlaceholders(player, text);
+    }
+
+    @Override
+    public @NotNull String setBracketPlaceholders(OfflinePlayer player, @NotNull String text) {
+        return PlaceholderAPI.setBracketPlaceholders(player, text);
+    }
+
+    @Override
+    public @NotNull List<String> setBracketPlaceholders(OfflinePlayer player, @NotNull List<String> text) {
+        return PlaceholderAPI.setBracketPlaceholders(player, text);
+    }
+
+    @Override
+    public String setBracketPlaceholders(Player player, @NotNull String text) {
+        return PlaceholderAPI.setBracketPlaceholders(player, text);
+    }
+
+    @Override
+    public List<String> setBracketPlaceholders(Player player, @NotNull List<String> text) {
+        return PlaceholderAPI.setBracketPlaceholders(player, text);
+    }
+
+    @Override
+    public String setRelationalPlaceholders(Player one, Player two, String text) {
+        return PlaceholderAPI.setRelationalPlaceholders(one, two, text);
+    }
+
+    @Override
+    public List<String> setRelationalPlaceholders(Player one, Player two, List<String> text) {
+        return PlaceholderAPI.setRelationalPlaceholders(one, two, text);
+    }
+
+    @Override
+    public boolean isRegistered(@NotNull String identifier) {
+        return PlaceholderAPI.isRegistered(identifier);
+    }
+
+    @Override
+    public Set<String> getRegisteredIdentifiers() {
+        return PlaceholderAPI.getRegisteredIdentifiers();
+    }
+
+    @Override
+    public Pattern getPlaceholderPattern() {
+        return PlaceholderAPI.getPlaceholderPattern();
+    }
+
+    @Override
+    public Pattern getBracketPlaceholderPattern() {
+        return PlaceholderAPI.getBracketPlaceholderPattern();
+    }
+
+    @Override
+    public Pattern getRelationalPlaceholderPattern() {
+        return PlaceholderAPI.getRelationalPlaceholderPattern();
+    }
+
+    @Override
+    public boolean containsPlaceholders(String text) {
+        return PlaceholderAPI.containsPlaceholders(text);
+    }
+
+    @Override
+    public boolean containsBracketPlaceholders(String text) {
+        return PlaceholderAPI.containsBracketPlaceholders(text);
+    }
+}

--- a/wolfyutilities/src/main/java/me/wolfyscript/utilities/compatibility/plugins/PlaceholderAPIImpl.java
+++ b/wolfyutilities/src/main/java/me/wolfyscript/utilities/compatibility/plugins/PlaceholderAPIImpl.java
@@ -19,11 +19,15 @@
 package me.wolfyscript.utilities.compatibility.plugins;
 
 import me.clip.placeholderapi.PlaceholderAPI;
+import me.clip.placeholderapi.events.ExpansionsLoadedEvent;
 import me.wolfyscript.utilities.annotations.WUPluginIntegration;
 import me.wolfyscript.utilities.api.WolfyUtilCore;
 import me.wolfyscript.utilities.compatibility.PluginIntegrationAbstract;
+import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
 import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.NotNull;
 
@@ -32,7 +36,7 @@ import java.util.Set;
 import java.util.regex.Pattern;
 
 @WUPluginIntegration(pluginName = PlaceholderAPIImpl.PLUGIN_NAME)
-public class PlaceholderAPIImpl extends PluginIntegrationAbstract implements PlaceholderAPIIntegration {
+public class PlaceholderAPIImpl extends PluginIntegrationAbstract implements PlaceholderAPIIntegration, Listener {
 
     static final String PLUGIN_NAME = "PlaceholderAPI";
 
@@ -47,12 +51,12 @@ public class PlaceholderAPIImpl extends PluginIntegrationAbstract implements Pla
 
     @Override
     public void init(Plugin plugin) {
-
+        Bukkit.getPluginManager().registerEvents(this, core);
     }
 
     @Override
     public boolean hasAsyncLoading() {
-        return false;
+        return true;
     }
 
     @Override
@@ -139,4 +143,12 @@ public class PlaceholderAPIImpl extends PluginIntegrationAbstract implements Pla
     public boolean containsBracketPlaceholders(String text) {
         return PlaceholderAPI.containsBracketPlaceholders(text);
     }
+
+    @EventHandler
+    public void onEnabled(ExpansionsLoadedEvent event) {
+        if (!this.isDoneLoading()) {
+            this.markAsDoneLoading();
+        }
+    }
+
 }

--- a/wolfyutilities/src/main/resources/plugin.yml
+++ b/wolfyutilities/src/main/resources/plugin.yml
@@ -23,6 +23,7 @@ softdepend:
   - Oraxen
   - ItemsAdder
   - ExecutableItems
+  - PlaceholderAPI
 
 commands:
   wolfyutils:


### PR DESCRIPTION
GuiWindows can now update their titles without being reopened or language reload.
For that there are a few new methods: 
- `onUpdateTitle(String originalTitle, @Nullable GUIInventory<C> inventory, GuiHandler<C> guiHandler)` - Called each title update.
- `setTitleUpdateDelay(int titleUpdateDelay)` - Set the initial delay after the inventory was opened.
- `setTitleUpdatePeriod(int titleUpdatePeriod)` - Set the delay of each title update.

Using these methods you can change the title dependent on your data. You can also set a repeating task that updates the title each specified period. 

Additionally, the titles support PlaceholderAPI now. Placeholders and BracketPlaceholders will be replaced if the PlaceholderAPI plugin is available.
For that there is a new PluginIntegration called `PlaceholderAPIIntegration` that allows you to call PlaceholderAPI methods without hooking into it on your own.
```java
PlaceholderAPIIntegration integration = wuAPI.getCore().getCompatibilityManager().getPlugins().getIntegration("PlaceholderAPI", PlaceholderAPIIntegration.class);
if (integration != null) {
    //PlaceholderAPI is available
    //use the integration e.g. integration.setPlaceholders(player, yourString);
}
```
or via the functional usage
```java
wolfyUtilities.getCore().getCompatibilityManager().getPlugins().runIfAvailable("PlaceholderAPI", PlaceholderAPIIntegration.class, integration -> {
    //PlaceholderAPI is available
    //use the integration e.g. integration.setPlaceholders(player, yourString); 
    //of course you need to use Atomics to edit variables outside of this lambda.
});
```

Resolves #45
Resolves WolfyScript/CustomCrafting#32