### PR TITLE
Plugin Adapters & Plugins implementation fixes

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <artifactId>wolfyutilities-parent</artifactId>
         <groupId>com.wolfyscript.wolfyutilities</groupId>
-        <version>3.16.0.0</version>
+        <version>3.16-SNAPSHOT</version>
     </parent>
     <build>
         <plugins>

--- a/core/src/main/java/me/wolfyscript/utilities/compatibility/PluginAdapter.java
+++ b/core/src/main/java/me/wolfyscript/utilities/compatibility/PluginAdapter.java
@@ -1,0 +1,40 @@
+/*
+ *       WolfyUtilities, APIs and Utilities for Minecraft Spigot plugins
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package me.wolfyscript.utilities.compatibility;
+
+import me.wolfyscript.utilities.util.NamespacedKey;
+
+/**
+ * These adapters are used for easier management of plugin dependent classes.<br>
+ * e.g. If you have a soft-depend and need to only register an object when it is available.
+ *
+ */
+public abstract class PluginAdapter {
+
+    private final NamespacedKey key;
+
+    protected PluginAdapter(NamespacedKey namespacedKey) {
+        this.key = namespacedKey;
+    }
+
+    public final NamespacedKey getNamespacedKey() {
+        return key;
+    }
+
+}

--- a/core/src/main/java/me/wolfyscript/utilities/compatibility/PluginIntegration.java
+++ b/core/src/main/java/me/wolfyscript/utilities/compatibility/PluginIntegration.java
@@ -20,6 +20,7 @@ package me.wolfyscript.utilities.compatibility;
 
 import me.wolfyscript.utilities.api.WolfyUtilCore;
 import me.wolfyscript.utilities.api.inventory.custom_items.references.APIReference;
+import me.wolfyscript.utilities.util.NamespacedKey;
 import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.Nullable;
 
@@ -61,4 +62,14 @@ public interface PluginIntegration {
      * @return True if the integration is done loading; else false.
      */
     boolean isDoneLoading();
+
+    /**
+     * Gets the registered adapter of this plugin and specified key.<br>
+     *
+     * @param type The type of the adapter.
+     * @param key The key of the adapter.
+     * @param <T> The PluginAdapter type.
+     * @return The adapter of the specified key; or null if it doesn't exist or doesn't match the type.
+     */
+    <T extends PluginAdapter> T getAdapter(Class<T> type, NamespacedKey key);
 }

--- a/core/src/main/java/me/wolfyscript/utilities/compatibility/PluginIntegrationAbstract.java
+++ b/core/src/main/java/me/wolfyscript/utilities/compatibility/PluginIntegrationAbstract.java
@@ -19,7 +19,10 @@
 package me.wolfyscript.utilities.compatibility;
 
 import me.wolfyscript.utilities.api.WolfyUtilCore;
+import me.wolfyscript.utilities.util.NamespacedKey;
 import org.bukkit.plugin.Plugin;
+
+import java.util.Map;
 
 /**
  * To add a PluginIntegration you need to extend this class and add the annotation {@link me.wolfyscript.utilities.annotations.WUPluginIntegration} to that class.<br>
@@ -107,6 +110,11 @@ public abstract class PluginIntegrationAbstract implements PluginIntegration {
     protected final void markAsDoneLoading() {
         setEnabled(true);
         ((PluginsImpl) core.getCompatibilityManager().getPlugins()).checkDependencies();
+    }
+
+    @Override
+    public <T extends PluginAdapter> T getAdapter(Class<T> type, NamespacedKey key) {
+        return core.getCompatibilityManager().getPlugins().getAdapter(pluginName, type, key);
     }
 
 }

--- a/core/src/main/java/me/wolfyscript/utilities/compatibility/Plugins.java
+++ b/core/src/main/java/me/wolfyscript/utilities/compatibility/Plugins.java
@@ -18,11 +18,13 @@
 
 package me.wolfyscript.utilities.compatibility;
 
+import me.wolfyscript.utilities.util.NamespacedKey;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Collection;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 /**
  * Manages compatibility with other plugins. <br>
@@ -128,5 +130,26 @@ public interface Plugins {
      * @return True if all integrations are done loading or there is nothing to load; else false.
      */
     boolean isDoneLoading();
+
+    /**
+     * Registers a new PluginAdapter if the specified plugin is available.<br>
+     * The plugin should be specified in your plugins <code>softdepend</code>.<br>
+     * If the plugin is not available when this method is called, then it'll do nothing.
+     *
+     * @param pluginName The plugin name, to register the adapter for.
+     * @param pluginAdapter The adapter supplier.
+     */
+    void registerAdapter(String pluginName, Supplier<PluginAdapter> pluginAdapter);
+
+    /**
+     * Gets the registered adapter for the specified plugin and key.<br>
+     *
+     * @param pluginName The plugin name.
+     * @param type The type of the adapter.
+     * @param key The key of the adapter.
+     * @param <T> The PluginAdapter type.
+     * @return The adapter of the specified key; or null if it doesn't exist or doesn't match the type.
+     */
+    <T extends PluginAdapter> T getAdapter(String pluginName, Class<T> type, NamespacedKey key);
 
 }

--- a/nmsutil/nmsutil-artifact/pom.xml
+++ b/nmsutil/nmsutil-artifact/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutilities</groupId>
-        <version>3.16.0.0</version>
+        <version>3.16-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/nmsutil-v1_15_R1/pom.xml
+++ b/nmsutil/nmsutil-v1_15_R1/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutilities</groupId>
-        <version>3.16.0.0</version>
+        <version>3.16-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/nmsutil-v1_16_R1/pom.xml
+++ b/nmsutil/nmsutil-v1_16_R1/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutilities</groupId>
-        <version>3.16.0.0</version>
+        <version>3.16-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/nmsutil-v1_16_R2/pom.xml
+++ b/nmsutil/nmsutil-v1_16_R2/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutilities</groupId>
-        <version>3.16.0.0</version>
+        <version>3.16-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/nmsutil-v1_16_R3/pom.xml
+++ b/nmsutil/nmsutil-v1_16_R3/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutilities</groupId>
-        <version>3.16.0.0</version>
+        <version>3.16-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/nmsutil-v1_17_R1_P0/pom.xml
+++ b/nmsutil/nmsutil-v1_17_R1_P0/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutilities</groupId>
-        <version>3.16.0.0</version>
+        <version>3.16-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/nmsutil-v1_17_R1_P1/pom.xml
+++ b/nmsutil/nmsutil-v1_17_R1_P1/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutilities</groupId>
-        <version>3.16.0.0</version>
+        <version>3.16-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/nmsutil-v1_18_R1_P0/pom.xml
+++ b/nmsutil/nmsutil-v1_18_R1_P0/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutilities</groupId>
-        <version>3.16.0.0</version>
+        <version>3.16-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/nmsutil-v1_18_R1_P1/pom.xml
+++ b/nmsutil/nmsutil-v1_18_R1_P1/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutilities</groupId>
-        <version>3.16.0.0</version>
+        <version>3.16-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/pom.xml
+++ b/nmsutil/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>wolfyutilities-parent</artifactId>
         <groupId>com.wolfyscript.wolfyutilities</groupId>
-        <version>3.16.0.0</version>
+        <version>3.16-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/plugin-compatibility-module/itemsadder/pom.xml
+++ b/plugin-compatibility-module/itemsadder/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>plugin-compatibility-module</artifactId>
         <groupId>com.wolfyscript.wolfyutilities</groupId>
-        <version>3.16.0.0</version>
+        <version>3.16-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/plugin-compatibility-module/magic/pom.xml
+++ b/plugin-compatibility-module/magic/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>plugin-compatibility-module</artifactId>
         <groupId>com.wolfyscript.wolfyutilities</groupId>
-        <version>3.16.0.0</version>
+        <version>3.16-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/plugin-compatibility-module/mmoitems/pom.xml
+++ b/plugin-compatibility-module/mmoitems/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>plugin-compatibility-module</artifactId>
         <groupId>com.wolfyscript.wolfyutilities</groupId>
-        <version>3.16.0.0</version>
+        <version>3.16-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/plugin-compatibility-module/mythicmobs/pom.xml
+++ b/plugin-compatibility-module/mythicmobs/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>plugin-compatibility-module</artifactId>
         <groupId>com.wolfyscript.wolfyutilities</groupId>
-        <version>3.16.0.0</version>
+        <version>3.16-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/plugin-compatibility-module/oraxen/pom.xml
+++ b/plugin-compatibility-module/oraxen/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>plugin-compatibility-module</artifactId>
         <groupId>com.wolfyscript.wolfyutilities</groupId>
-        <version>3.16.0.0</version>
+        <version>3.16-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/plugin-compatibility-module/plugin-compatibility-artifact/pom.xml
+++ b/plugin-compatibility-module/plugin-compatibility-artifact/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>plugin-compatibility-module</artifactId>
         <groupId>com.wolfyscript.wolfyutilities</groupId>
-        <version>3.16.0.0</version>
+        <version>3.16-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/plugin-compatibility-module/pom.xml
+++ b/plugin-compatibility-module/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>wolfyutilities-parent</artifactId>
         <groupId>com.wolfyscript.wolfyutilities</groupId>
-        <version>3.16.0.0</version>
+        <version>3.16-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.wolfyscript.wolfyutilities</groupId>
     <artifactId>wolfyutilities-parent</artifactId>
-    <version>3.16.0.0</version>
+    <version>3.16-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/wolfyutilities/pom.xml
+++ b/wolfyutilities/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <artifactId>wolfyutilities-parent</artifactId>
         <groupId>com.wolfyscript.wolfyutilities</groupId>
-        <version>3.16.0.0</version>
+        <version>3.16-SNAPSHOT</version>
     </parent>
     <dependencies>
         <dependency>


### PR DESCRIPTION
Adds plugin adapters as an util to manage plugin dependent listeners or other classes.

A manager is registered using the method `Plugins#registerAdapter(pluginName : String, adapter : Supplier<PluginAdapter>)`.
The supplier is only called if the specified plugin is available at the time of invocation.

The adapter just requires a NamespacedKey, as you can register multiple adapters for a single plugin.
You can then get it via `Plugins#getAdapter(pluginName : String, type : Class<T>, key : NamespacedKey)`

Bug Fixes
- Fixed - PluginImplementations, that cause a RuntimeException,  are not removed from the registered implementations. Which means it is never activated.