### PR TITLE
Updated Adventure to latest dev

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <artifactId>wolfyutilities-parent</artifactId>
         <groupId>com.wolfyscript.wolfyutilities</groupId>
-        <version>3.16.1.0</version>
+        <version>3.16-SNAPSHOT</version>
     </parent>
     <build>
         <plugins>

--- a/core/src/main/java/me/wolfyscript/utilities/api/chat/Chat.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/chat/Chat.java
@@ -25,7 +25,7 @@ import me.wolfyscript.utilities.util.Pair;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.event.ClickEvent;
 import net.kyori.adventure.text.minimessage.MiniMessage;
-import net.kyori.adventure.text.minimessage.Template;
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import net.md_5.bungee.api.chat.TextComponent;
 import org.bukkit.entity.Player;
 
@@ -233,10 +233,10 @@ public abstract class Chat {
      * If it is not available it returns an empty component.
      *
      * @param key The key in the language.
-     * @param templates The placeholders and values in the message.
+     * @param resolvers The custom tag resolvers to use.
      * @return The component set for the key; empty component if not available.
      */
-    public abstract Component translated(String key, List<Template> templates);
+    public abstract Component translated(String key, List<? extends TagResolver> resolvers);
 
     /**
      * Creates a {@link Component} of the specified language key.<br>
@@ -244,11 +244,11 @@ public abstract class Chat {
      * If it is not available it returns an empty component.
      *
      * @param key The key in the language.
-     * @param templates The placeholders and values in the message.
+     * @param resolvers The custom tag resolvers to use.
      * @param translateLegacyColor If it should translate legacy '&' color codes.
      * @return The component set for the key; empty component if not available.
      */
-    public abstract Component translated(String key, boolean translateLegacyColor, List<Template> templates);
+    public abstract Component translated(String key, boolean translateLegacyColor, List<? extends TagResolver> resolvers);
 
     /**
      * Creates a ClickEvent, that executes code when clicked.<br>

--- a/core/src/main/java/me/wolfyscript/utilities/api/chat/ChatImpl.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/chat/ChatImpl.java
@@ -28,8 +28,8 @@ import me.wolfyscript.utilities.util.chat.ChatColor;
 import net.kyori.adventure.platform.bukkit.BukkitComponentSerializer;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.MiniMessage;
-import net.kyori.adventure.text.minimessage.Template;
-import net.kyori.adventure.text.minimessage.markdown.DiscordFlavor;
+import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import net.kyori.adventure.text.serializer.bungeecord.BungeeComponentSerializer;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import net.md_5.bungee.api.chat.TextComponent;
@@ -67,11 +67,7 @@ public class ChatImpl extends Chat {
         this.languageAPI = wolfyUtilities.getLanguageAPI();
         this.plugin = wolfyUtilities.getPlugin();
         this.chatPrefix = Component.text("[" + plugin.getName() + "]");
-        this.miniMessage = MiniMessage.builder().markdown().markdownFlavor(DiscordFlavor.get()).parsingErrorMessageConsumer(strings -> {
-            for (String string : strings) {
-                wolfyUtilities.getConsole().getLogger().warning(string);
-            }
-        }).build();
+        this.miniMessage = MiniMessage.miniMessage();
         this.LEGACY_SERIALIZER = BukkitComponentSerializer.legacy();
         this.BUNGEE_SERIALIZER = BungeeComponentSerializer.get();
     }
@@ -236,8 +232,8 @@ public class ChatImpl extends Chat {
         sendMessage(player, translated("inventories." + namespacedKey.getNamespace() + "." + namespacedKey.getKey() + ".messages." + msgKey, true, getTemplates(replacements)));
     }
 
-    private List<Template> getTemplates(Pair<String, String>[] replacements) {
-        return Arrays.stream(replacements).map(pair -> Template.of(pair.getKey(), pair.getValue())).toList();
+    private List<? extends TagResolver> getTemplates(Pair<String, String>[] replacements) {
+        return Arrays.stream(replacements).map(pair -> Placeholder.unparsed(pair.getKey(), pair.getValue())).toList();
     }
 
     @Override
@@ -251,13 +247,13 @@ public class ChatImpl extends Chat {
     }
 
     @Override
-    public Component translated(String key, List<Template> templates) {
-        return languageAPI.getComponent(key, templates);
+    public Component translated(String key, List<? extends TagResolver> resolvers) {
+        return languageAPI.getComponent(key, resolvers);
     }
 
     @Override
-    public Component translated(String key, boolean translateLegacyColor, List<Template> templates) {
-        return languageAPI.getComponent(key, translateLegacyColor, templates);
+    public Component translated(String key, boolean translateLegacyColor, List<? extends TagResolver> resolvers) {
+        return languageAPI.getComponent(key, translateLegacyColor, resolvers);
     }
 
     /**

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/GuiCluster.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/GuiCluster.java
@@ -28,7 +28,7 @@ import me.wolfyscript.utilities.api.inventory.gui.button.buttons.ToggleButton;
 import me.wolfyscript.utilities.api.inventory.gui.cache.CustomCache;
 import me.wolfyscript.utilities.util.NamespacedKey;
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.minimessage.Template;
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 
 import java.util.HashMap;
 import java.util.List;
@@ -140,7 +140,7 @@ public abstract class GuiCluster<C extends CustomCache> extends GuiMenuComponent
      * @return The component set for the key; empty component if not available.
      */
     @Override
-    public Component translatedMsgKey(String key, boolean translateLegacyColor, List<Template> templates) {
+    public Component translatedMsgKey(String key, boolean translateLegacyColor, List<? extends TagResolver> templates) {
         return getChat().translated("inventories." + id + ".global_messages." + key, translateLegacyColor, templates);
     }
 

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/GuiMenuComponent.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/GuiMenuComponent.java
@@ -29,7 +29,7 @@ import me.wolfyscript.utilities.api.inventory.gui.button.buttons.MultipleChoiceB
 import me.wolfyscript.utilities.api.inventory.gui.button.buttons.ToggleButton;
 import me.wolfyscript.utilities.api.inventory.gui.cache.CustomCache;
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.minimessage.Template;
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.HashMap;
@@ -154,7 +154,7 @@ public abstract class GuiMenuComponent<C extends CustomCache> {
      * @param templates The placeholders and values in the message.
      * @return The component set for the key; empty component if not available.
      */
-    public Component translatedMsgKey(String key, List<Template> templates) {
+    public Component translatedMsgKey(String key, List<? extends TagResolver> templates) {
         return translatedMsgKey(key, false, templates);
     }
 
@@ -168,7 +168,7 @@ public abstract class GuiMenuComponent<C extends CustomCache> {
      * @param translateLegacyColor If it should translate legacy '&' color codes.
      * @return The component set for the key; empty component if not available.
      */
-    public abstract Component translatedMsgKey(String key, boolean translateLegacyColor, List<Template> templates);
+    public abstract Component translatedMsgKey(String key, boolean translateLegacyColor, List<? extends TagResolver> templates);
 
     /**
      * Opens the chat, send the player the defined message and waits for the input of the player.

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/GuiWindow.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/GuiWindow.java
@@ -36,7 +36,7 @@ import me.wolfyscript.utilities.util.Pair;
 import me.wolfyscript.utilities.util.chat.ChatColor;
 import me.wolfyscript.utilities.util.reflection.InventoryUpdate;
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.minimessage.Template;
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Listener;
@@ -394,7 +394,7 @@ public abstract class GuiWindow<C extends CustomCache> extends GuiMenuComponent<
      * @return The translated Component of that message; Or empty Component if non-existing.
      */
     @Override
-    public Component translatedMsgKey(String key, boolean translateLegacyColor, List<Template> templates) {
+    public Component translatedMsgKey(String key, boolean translateLegacyColor, List<? extends TagResolver> templates) {
         return getChat().translated("inventories." + getNamespacedKey().getNamespace() + "." + getNamespacedKey().getKey() + ".messages." + key, translateLegacyColor, templates);
     }
 

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/button/ButtonState.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/button/ButtonState.java
@@ -27,7 +27,7 @@ import me.wolfyscript.utilities.api.inventory.gui.cache.CustomCache;
 import me.wolfyscript.utilities.util.NamespacedKey;
 import me.wolfyscript.utilities.util.inventory.ItemUtils;
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.minimessage.Template;
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.Nullable;
@@ -423,7 +423,7 @@ public class ButtonState<C extends CustomCache> {
         return getName(window, List.of());
     }
 
-    public Component getName(GuiWindow<C> window, List<Template> templates) {
+    public Component getName(GuiWindow<C> window, List<? extends TagResolver> templates) {
         if (clusterID != null) {
             return wolfyUtilities.getLanguageAPI().getComponent(String.format(BUTTON_CLUSTER_KEY + NAME_KEY, clusterID, key), true, templates);
         }
@@ -434,7 +434,7 @@ public class ButtonState<C extends CustomCache> {
         return getLore(window, List.of());
     }
 
-    public List<Component> getLore(GuiWindow<C> window, List<Template> templates) {
+    public List<Component> getLore(GuiWindow<C> window, List<? extends TagResolver> templates) {
         if (clusterID != null) {
             return wolfyUtilities.getLanguageAPI().getComponents(String.format(BUTTON_CLUSTER_KEY + LORE_KEY, clusterID, key), true, templates);
         }

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/button/CallbackButtonRender.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/button/CallbackButtonRender.java
@@ -21,7 +21,7 @@ package me.wolfyscript.utilities.api.inventory.gui.button;
 import me.wolfyscript.utilities.api.inventory.gui.GuiHandler;
 import me.wolfyscript.utilities.api.inventory.gui.cache.CustomCache;
 import me.wolfyscript.utilities.api.nms.inventory.GUIInventory;
-import net.kyori.adventure.text.minimessage.Template;
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
@@ -47,7 +47,7 @@ public interface CallbackButtonRender<C extends CustomCache> extends ButtonRende
      * @param slot         The slot in which the button is rendered.
      * @return The itemStack that should be set into the GUI.
      */
-    ItemStack render(List<Template> values, C cache, GuiHandler<C> guiHandler, Player player, GUIInventory<C> guiInventory, ItemStack itemStack, int slot);
+    ItemStack render(List<? extends TagResolver> values, C cache, GuiHandler<C> guiHandler, Player player, GUIInventory<C> guiInventory, ItemStack itemStack, int slot);
 
     default ItemStack render(HashMap<String, Object> values, C cache, GuiHandler<C> guiHandler, Player player, GUIInventory<C> guiInventory, ItemStack itemStack, int slot, boolean helpEnabled) {
         return render(List.of(), cache, guiHandler, player, guiInventory, itemStack, slot);

--- a/core/src/main/java/me/wolfyscript/utilities/api/language/LanguageAPI.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/language/LanguageAPI.java
@@ -27,7 +27,7 @@ import me.wolfyscript.utilities.util.chat.ChatColor;
 import me.wolfyscript.utilities.util.json.jackson.JacksonUtil;
 import net.kyori.adventure.platform.bukkit.BukkitComponentSerializer;
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.minimessage.Template;
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
@@ -169,12 +169,12 @@ public class LanguageAPI {
         return getComponent(key, translateLegacyColor, List.of());
     }
 
-    public Component getComponent(String key, List<Template> templates) {
-        return getComponent(key, false, templates);
+    public Component getComponent(String key, List<? extends TagResolver> resolvers) {
+        return getComponent(key, false, resolvers);
     }
 
-    public Component getComponent(String key, boolean translateLegacyColor, List<Template> templates) {
-        return getNode(key).getComponent(translateLegacyColor, templates);
+    public Component getComponent(String key, boolean translateLegacyColor, List<? extends TagResolver> resolvers) {
+        return getNode(key).getComponent(translateLegacyColor, resolvers);
     }
 
     public List<Component> getComponents(String key) {
@@ -185,12 +185,12 @@ public class LanguageAPI {
         return getComponents(key, translateLegacyColor, List.of());
     }
 
-    public List<Component> getComponents(String key, List<Template> templates) {
-        return getComponents(key, false, templates);
+    public List<Component> getComponents(String key, List<? extends TagResolver> resolvers) {
+        return getComponents(key, false, resolvers);
     }
 
-    public List<Component> getComponents(String key, boolean translateLegacyColor, List<Template> templates) {
-        return getNode(key).getComponents(translateLegacyColor, templates);
+    public List<Component> getComponents(String key, boolean translateLegacyColor, List<? extends TagResolver> resolvers) {
+        return getNode(key).getComponents(translateLegacyColor, resolvers);
     }
 
     public String replaceKeys(String msg) {

--- a/core/src/main/java/me/wolfyscript/utilities/api/language/LanguageNode.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/language/LanguageNode.java
@@ -22,7 +22,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.databind.JsonNode;
 import me.wolfyscript.utilities.api.chat.Chat;
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.minimessage.Template;
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 
 import java.util.List;
 
@@ -36,9 +36,9 @@ public abstract class LanguageNode {
         this.value = value;
     }
 
-    abstract public Component getComponent(boolean translateLegacyColor, List<Template> templates);
+    abstract public Component getComponent(boolean translateLegacyColor, List<? extends TagResolver> templates);
 
-    abstract public List<Component> getComponents(boolean translateLegacyColor, List<Template> templates);
+    abstract public List<Component> getComponents(boolean translateLegacyColor, List<? extends TagResolver> templates);
 
     abstract public String getRaw();
 

--- a/core/src/main/java/me/wolfyscript/utilities/api/language/LanguageNodeArray.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/language/LanguageNodeArray.java
@@ -22,7 +22,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import me.wolfyscript.utilities.api.chat.Chat;
 import me.wolfyscript.utilities.util.chat.ChatColor;
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.minimessage.Template;
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -51,17 +51,17 @@ public class LanguageNodeArray extends LanguageNode {
     }
 
     @Override
-    public Component getComponent(boolean translateLegacyColor, List<Template> templates) {
-        return chat.getMiniMessage().parse(translateLegacyColor ? rawLegacyLine : rawLine, templates);
+    public Component getComponent(boolean translateLegacyColor, List<? extends TagResolver> templates) {
+        return chat.getMiniMessage().deserialize(translateLegacyColor ? rawLegacyLine : rawLine, templates.toArray(TagResolver[]::new));
     }
 
     @Override
-    public List<Component> getComponents(boolean translateLegacyColor, List<Template> templates) {
+    public List<Component> getComponents(boolean translateLegacyColor, List<? extends TagResolver> templates) {
         return translateLegacyColor ? getComponents(rawLegacy, templates) : getComponents(raw, templates);
     }
 
-    private List<Component> getComponents(List<String> rawValues, List<Template> templates) {
-        return rawValues.stream().map(s -> chat.getMiniMessage().parse(s, templates)).collect(Collectors.toList());
+    private List<Component> getComponents(List<String> rawValues, List<? extends TagResolver> templates) {
+        return rawValues.stream().map(s -> chat.getMiniMessage().deserialize(s, templates.toArray(TagResolver[]::new))).collect(Collectors.toList());
     }
 
     @Override

--- a/core/src/main/java/me/wolfyscript/utilities/api/language/LanguageNodeMissing.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/language/LanguageNodeMissing.java
@@ -21,7 +21,7 @@ package me.wolfyscript.utilities.api.language;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import me.wolfyscript.utilities.api.chat.Chat;
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.minimessage.Template;
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 
 import java.util.List;
 
@@ -32,13 +32,13 @@ public class LanguageNodeMissing extends LanguageNode {
     }
 
     @Override
-    public Component getComponent(boolean translateLegacyColor, List<Template> templates) {
+    public Component getComponent(boolean translateLegacyColor, List<? extends TagResolver> templates) {
         return Component.empty();
     }
 
     @Override
-    public List<Component> getComponents(boolean translateLegacyColor, List<Template> templates) {
-        return List.of(Component.empty());
+    public List<Component> getComponents(boolean translateLegacyColor, List<? extends TagResolver> templates) {
+        return List.of();
     }
 
     @Override

--- a/core/src/main/java/me/wolfyscript/utilities/api/language/LanguageNodeText.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/language/LanguageNodeText.java
@@ -22,7 +22,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import me.wolfyscript.utilities.api.chat.Chat;
 import me.wolfyscript.utilities.util.chat.ChatColor;
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.minimessage.Template;
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 
 import java.util.List;
 
@@ -38,13 +38,13 @@ public class LanguageNodeText extends LanguageNode {
     }
 
     @Override
-    public Component getComponent(boolean translateLegacyColor, List<Template> templates) {
-        return chat.getMiniMessage().parse(translateLegacyColor ? rawLegacy : raw, templates);
+    public Component getComponent(boolean translateLegacyColor, List<? extends TagResolver> templates) {
+        return chat.getMiniMessage().deserialize(translateLegacyColor ? rawLegacy : raw, templates.toArray(TagResolver[]::new));
     }
 
     @Override
-    public List<Component> getComponents(boolean translateLegacyColor, List<Template> templates) {
-        return List.of(chat.getMiniMessage().parse(translateLegacyColor ? rawLegacy : raw, templates));
+    public List<Component> getComponents(boolean translateLegacyColor, List<? extends TagResolver> templates) {
+        return List.of(chat.getMiniMessage().deserialize(translateLegacyColor ? rawLegacy : raw, templates.toArray(TagResolver[]::new)));
     }
 
     @Override

--- a/nmsutil/nmsutil-artifact/pom.xml
+++ b/nmsutil/nmsutil-artifact/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutilities</groupId>
-        <version>3.16.1.0</version>
+        <version>3.16-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/nmsutil-v1_15_R1/pom.xml
+++ b/nmsutil/nmsutil-v1_15_R1/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutilities</groupId>
-        <version>3.16.1.0</version>
+        <version>3.16-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/nmsutil-v1_16_R1/pom.xml
+++ b/nmsutil/nmsutil-v1_16_R1/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutilities</groupId>
-        <version>3.16.1.0</version>
+        <version>3.16-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/nmsutil-v1_16_R2/pom.xml
+++ b/nmsutil/nmsutil-v1_16_R2/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutilities</groupId>
-        <version>3.16.1.0</version>
+        <version>3.16-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/nmsutil-v1_16_R3/pom.xml
+++ b/nmsutil/nmsutil-v1_16_R3/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutilities</groupId>
-        <version>3.16.1.0</version>
+        <version>3.16-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/nmsutil-v1_17_R1_P0/pom.xml
+++ b/nmsutil/nmsutil-v1_17_R1_P0/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutilities</groupId>
-        <version>3.16.1.0</version>
+        <version>3.16-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/nmsutil-v1_17_R1_P1/pom.xml
+++ b/nmsutil/nmsutil-v1_17_R1_P1/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutilities</groupId>
-        <version>3.16.1.0</version>
+        <version>3.16-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/nmsutil-v1_18_R1_P0/pom.xml
+++ b/nmsutil/nmsutil-v1_18_R1_P0/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutilities</groupId>
-        <version>3.16.1.0</version>
+        <version>3.16-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/nmsutil-v1_18_R1_P1/pom.xml
+++ b/nmsutil/nmsutil-v1_18_R1_P1/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>nmsutil</artifactId>
         <groupId>com.wolfyscript.wolfyutilities</groupId>
-        <version>3.16.1.0</version>
+        <version>3.16-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nmsutil/pom.xml
+++ b/nmsutil/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>wolfyutilities-parent</artifactId>
         <groupId>com.wolfyscript.wolfyutilities</groupId>
-        <version>3.16.1.0</version>
+        <version>3.16-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/plugin-compatibility-module/eco/pom.xml
+++ b/plugin-compatibility-module/eco/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>plugin-compatibility-module</artifactId>
         <groupId>com.wolfyscript.wolfyutilities</groupId>
-        <version>3.16.1.0</version>
+        <version>3.16-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/plugin-compatibility-module/itemsadder/pom.xml
+++ b/plugin-compatibility-module/itemsadder/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>plugin-compatibility-module</artifactId>
         <groupId>com.wolfyscript.wolfyutilities</groupId>
-        <version>3.16.1.0</version>
+        <version>3.16-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/plugin-compatibility-module/magic/pom.xml
+++ b/plugin-compatibility-module/magic/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>plugin-compatibility-module</artifactId>
         <groupId>com.wolfyscript.wolfyutilities</groupId>
-        <version>3.16.1.0</version>
+        <version>3.16-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/plugin-compatibility-module/mmoitems/pom.xml
+++ b/plugin-compatibility-module/mmoitems/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>plugin-compatibility-module</artifactId>
         <groupId>com.wolfyscript.wolfyutilities</groupId>
-        <version>3.16.1.0</version>
+        <version>3.16-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/plugin-compatibility-module/mythicmobs/pom.xml
+++ b/plugin-compatibility-module/mythicmobs/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>plugin-compatibility-module</artifactId>
         <groupId>com.wolfyscript.wolfyutilities</groupId>
-        <version>3.16.1.0</version>
+        <version>3.16-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/plugin-compatibility-module/oraxen/pom.xml
+++ b/plugin-compatibility-module/oraxen/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>plugin-compatibility-module</artifactId>
         <groupId>com.wolfyscript.wolfyutilities</groupId>
-        <version>3.16.1.0</version>
+        <version>3.16-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/plugin-compatibility-module/plugin-compatibility-artifact/pom.xml
+++ b/plugin-compatibility-module/plugin-compatibility-artifact/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>plugin-compatibility-module</artifactId>
         <groupId>com.wolfyscript.wolfyutilities</groupId>
-        <version>3.16.1.0</version>
+        <version>3.16-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/plugin-compatibility-module/pom.xml
+++ b/plugin-compatibility-module/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>wolfyutilities-parent</artifactId>
         <groupId>com.wolfyscript.wolfyutilities</groupId>
-        <version>3.16.1.0</version>
+        <version>3.16-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.wolfyscript.wolfyutilities</groupId>
     <artifactId>wolfyutilities-parent</artifactId>
-    <version>3.16.1.0</version>
+    <version>3.16-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>
@@ -81,13 +81,13 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>4.2.0</version>
+            <version>4.3.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.github.seeseemelk</groupId>
             <artifactId>MockBukkit-v1.18</artifactId>
-            <version>1.15.0</version>
+            <version>1.15.5</version>
             <scope>test</scope>
         </dependency>
         <!--Spigot API-->
@@ -134,7 +134,7 @@
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-api</artifactId>
-            <version>4.9.3</version>
+            <version>4.10.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -146,7 +146,7 @@
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-text-minimessage</artifactId>
-            <version>4.1.0-SNAPSHOT</version>
+            <version>4.10.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <!-- LWC by Brokkonaut for entity locking -->

--- a/wolfyutilities/pom.xml
+++ b/wolfyutilities/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <artifactId>wolfyutilities-parent</artifactId>
         <groupId>com.wolfyscript.wolfyutilities</groupId>
-        <version>3.16.1.0</version>
+        <version>3.16-SNAPSHOT</version>
     </parent>
     <dependencies>
         <dependency>
@@ -60,7 +60,7 @@
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-api</artifactId>
-            <version>4.9.3</version>
+            <version>4.10.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -72,7 +72,7 @@
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-text-minimessage</artifactId>
-            <version>4.1.0-SNAPSHOT</version>
+            <version>4.10.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
         <!-- NMS module -->
@@ -135,8 +135,8 @@
                                     <shadedPattern>me.wolfyscript.lib.com.fasterxml.jackson</shadedPattern>
                                 </relocation>
                                 <relocation>
-                                    <pattern>net.kyori</pattern>
-                                    <shadedPattern>me.wolfyscript.lib.net.kyori</shadedPattern>
+                                    <pattern>net.kyori.adventure</pattern>
+                                    <shadedPattern>me.wolfyscript.lib.net.kyori.adventure</shadedPattern>
                                 </relocation>
                             </relocations>
                             <shadeSourcesContent>true</shadeSourcesContent>


### PR DESCRIPTION
Updated to latest dev version of Adventure (`4.10.0-SNAPSHOT`). 
This fixes some issues and warning messages that were spammed, when parsing button names and lore, and messages.

## Backwards compatibility issues
Since the API of Adventures MiniMessage was heavily changed. Backwards compatibility with things like `Templates` is broken.
This will only affect you if you made use of the methods that used the `Template` class, like `Chat#translated(String, List<Template>)`.
All appearences of `Template` were replaced with the new `TagResolver`, which also provides a lot more functionality.