### PR TITLE
ItemInputButton renders incorrect item

### DIFF
--- a/core/src/main/java/me/wolfyscript/utilities/api/chat/ChatImpl.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/chat/ChatImpl.java
@@ -69,7 +69,8 @@ public class ChatImpl extends Chat {
         this.chatPrefix = Component.text("[" + plugin.getName() + "]");
         this.miniMessage = MiniMessage.builder().markdown().markdownFlavor(DiscordFlavor.get()).parsingErrorMessageConsumer(strings -> {
             for (String string : strings) {
-                wolfyUtilities.getConsole().getLogger().warning(string);
+                //TODO: Config setting for that. As it is useful when creating lang files.
+                //wolfyUtilities.getConsole().getLogger().warning(string);
             }
         }).build();
         this.LEGACY_SERIALIZER = BukkitComponentSerializer.legacy();

--- a/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/button/buttons/ItemInputButton.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/inventory/gui/button/buttons/ItemInputButton.java
@@ -100,7 +100,11 @@ public class ItemInputButton<C extends CustomCache> extends ActionButton<C> {
 
     @Override
     public void render(GuiHandler<C> guiHandler, Player player, GUIInventory<C> guiInventory, Inventory inventory, ItemStack itemStack, int slot, boolean help) throws IOException {
-        applyItem(guiHandler, player, guiInventory, inventory, getState(), getContent(guiHandler), slot, help);
+        ItemStack item = getContent(guiHandler);
+        if (getState().getRenderAction() != null) {
+            item = getState().getRenderAction().render(new HashMap<>(), guiHandler.getCustomCache(), guiHandler, player, guiInventory, item, slot, help);
+        }
+        inventory.setItem(slot, item);
     }
 
     public ItemStack getContent(GuiHandler<C> guiHandler) {

--- a/core/src/main/java/me/wolfyscript/utilities/api/language/LanguageNodeMissing.java
+++ b/core/src/main/java/me/wolfyscript/utilities/api/language/LanguageNodeMissing.java
@@ -38,7 +38,7 @@ public class LanguageNodeMissing extends LanguageNode {
 
     @Override
     public List<Component> getComponents(boolean translateLegacyColor, List<Template> templates) {
-        return List.of(Component.empty());
+        return List.of();
     }
 
     @Override


### PR DESCRIPTION
The ItemInputButton tries to translate legacy colors in the name and lore of the item and fails, which then resets the display name and lore of the item.

This PR makes sure that ItemInputButtons no longer edit the item put in in any way (With the exception of the render callback).