### PR TITLE
Better ValueProviders

### DIFF
--- a/core/src/main/java/me/wolfyscript/utilities/util/json/jackson/KeyedTypeIdResolver.java
+++ b/core/src/main/java/me/wolfyscript/utilities/util/json/jackson/KeyedTypeIdResolver.java
@@ -115,6 +115,7 @@ public class KeyedTypeIdResolver extends TypeIdResolverBase {
             if (baseTypeAnnot != null) {
                 rawClass = baseTypeAnnot.baseType();
             }
+            //Get the registry of the required base type
             var registry = TYPE_REGISTRIES.get(rawClass);
             if (registry != null) {
                 var object = registry.get(key);
@@ -123,7 +124,8 @@ public class KeyedTypeIdResolver extends TypeIdResolverBase {
                 } else if(object instanceof Keyed) {
                     return object.getClass();
                 }
-            } else if(!TYPE_CLASS_REGISTRIES_OLD.isEmpty() || !TYPE_REGISTRIES_OLD.isEmpty()) { //Only try to get data from the old registries if required.
+            } else if(!TYPE_CLASS_REGISTRIES_OLD.isEmpty() || !TYPE_REGISTRIES_OLD.isEmpty()) {
+                //Only try to get data from the old registries if required.
                 var classRegistry = TYPE_CLASS_REGISTRIES_OLD.get(superType.getRawClass());
                 if (classRegistry != null) {
                     return classRegistry.get(key);

--- a/core/src/main/java/me/wolfyscript/utilities/util/json/jackson/RegexDeserializer.java
+++ b/core/src/main/java/me/wolfyscript/utilities/util/json/jackson/RegexDeserializer.java
@@ -1,0 +1,80 @@
+/*
+ *       WolfyUtilities, APIs and Utilities for Minecraft Spigot plugins
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package me.wolfyscript.utilities.util.json.jackson;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import me.wolfyscript.utilities.api.WolfyUtilCore;
+import me.wolfyscript.utilities.util.json.jackson.annotations.OptionalRegexCreator;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class RegexDeserializer<T> extends ValueDeserializer<T> {
+
+    private static final Map<Class<?>, Map<OptionalRegexCreator, Pattern>> cachedPatterns = new HashMap<>();
+
+    public RegexDeserializer(Class<T> type) {
+        super(type);
+        if (!cachedPatterns.containsKey(type)) {
+            Map<OptionalRegexCreator, Pattern> subTypePatterns = new HashMap<>();
+
+            for (Class<? extends T> subType : WolfyUtilCore.getInstance().getReflections().getSubTypesOf(type)) {
+                OptionalRegexCreator regexCreator = subType.getAnnotation(OptionalRegexCreator.class);
+                subTypePatterns.put(regexCreator, Pattern.compile(regexCreator.regex()));
+            }
+            cachedPatterns.put(type, subTypePatterns);
+        }
+    }
+
+    @Override
+    public T deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JsonProcessingException {
+        JsonNode node = p.readValueAsTree();
+        if (node.isTextual()) {
+            String text = node.asText();
+            if (!text.isBlank()) {
+                for (Map.Entry<OptionalRegexCreator, Pattern> entry : cachedPatterns.get(this.type).entrySet()) {
+                    OptionalRegexCreator.RegexCreator<T> regexCreator;
+                    try {
+                        OptionalRegexCreator.RegexCreator<?> unknownRegexCreator = entry.getKey().creator().getDeclaredConstructor().newInstance();
+                        if (this.type.isAssignableFrom(unknownRegexCreator.getType())) {
+                            regexCreator = (OptionalRegexCreator.RegexCreator<T>) unknownRegexCreator;
+                        } else {
+                            throw new IllegalArgumentException("ValueDeserializer of type \"" + unknownRegexCreator.getType().getName() + "\" cannot construct type \"" + this.type.getName() + "\"");
+                        }
+                    } catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+                        e.printStackTrace();
+                        continue;
+                    }
+                    Matcher matcher = entry.getValue().matcher(text);
+                    T value = regexCreator.create(matcher);
+                    if (value != null) return value;
+                }
+            }
+        }
+        return null;
+    }
+
+}

--- a/core/src/main/java/me/wolfyscript/utilities/util/json/jackson/ValueDeserializer.java
+++ b/core/src/main/java/me/wolfyscript/utilities/util/json/jackson/ValueDeserializer.java
@@ -1,0 +1,40 @@
+/*
+ *       WolfyUtilities, APIs and Utilities for Minecraft Spigot plugins
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package me.wolfyscript.utilities.util.json.jackson;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+
+import java.io.IOException;
+
+public abstract class ValueDeserializer<T> {
+
+    protected Class<T> type;
+
+    protected ValueDeserializer(Class<T> type) {
+        this.type = type;
+    }
+
+    public abstract T deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JsonProcessingException;
+
+    public Class<T> getType() {
+        return type;
+    }
+}

--- a/core/src/main/java/me/wolfyscript/utilities/util/json/jackson/ValueSerializer.java
+++ b/core/src/main/java/me/wolfyscript/utilities/util/json/jackson/ValueSerializer.java
@@ -1,0 +1,39 @@
+/*
+ *       WolfyUtilities, APIs and Utilities for Minecraft Spigot plugins
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package me.wolfyscript.utilities.util.json.jackson;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+import java.io.IOException;
+
+public abstract class ValueSerializer<T> {
+
+    protected Class<T> type;
+
+    protected ValueSerializer(Class<T> type) {
+        this.type = type;
+    }
+
+    public abstract boolean serialize(T targetObject, JsonGenerator generator, SerializerProvider provider) throws IOException;
+
+    public Class<T> getType() {
+        return type;
+    }
+}

--- a/core/src/main/java/me/wolfyscript/utilities/util/json/jackson/annotations/OptionalRegexCreator.java
+++ b/core/src/main/java/me/wolfyscript/utilities/util/json/jackson/annotations/OptionalRegexCreator.java
@@ -1,0 +1,50 @@
+/*
+ *       WolfyUtilities, APIs and Utilities for Minecraft Spigot plugins
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package me.wolfyscript.utilities.util.json.jackson.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.regex.Matcher;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface OptionalRegexCreator {
+
+    String regex();
+
+    Class<? extends RegexCreator<?>> creator();
+
+    abstract class RegexCreator<T> {
+
+        protected Class<T> type;
+
+        protected RegexCreator(Class<T> type) {
+            this.type = type;
+        }
+
+        public abstract T create(Matcher matcher);
+
+        public Class<T> getType() {
+            return type;
+        }
+    }
+
+}

--- a/core/src/main/java/me/wolfyscript/utilities/util/json/jackson/annotations/OptionalValueDeserializer.java
+++ b/core/src/main/java/me/wolfyscript/utilities/util/json/jackson/annotations/OptionalValueDeserializer.java
@@ -1,0 +1,108 @@
+/*
+ *       WolfyUtilities, APIs and Utilities for Minecraft Spigot plugins
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package me.wolfyscript.utilities.util.json.jackson.annotations;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.BeanDescription;
+import com.fasterxml.jackson.databind.DeserializationConfig;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.deser.BeanDeserializerModifier;
+import com.fasterxml.jackson.databind.deser.ResolvableDeserializer;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.jsontype.TypeDeserializer;
+import me.wolfyscript.utilities.util.json.jackson.ValueDeserializer;
+
+import java.io.IOException;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.reflect.InvocationTargetException;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface OptionalValueDeserializer {
+
+    Class<? extends ValueDeserializer<?>> deserializer();
+
+    final class DeserializerModifier extends BeanDeserializerModifier {
+
+        @Override
+        public JsonDeserializer<?> modifyDeserializer(DeserializationConfig config, BeanDescription beanDesc, JsonDeserializer<?> deserializer) {
+            var handledType = deserializer.handledType();
+            var annotation = handledType.getAnnotation(OptionalValueDeserializer.class);
+            if (annotation != null) {
+                try {
+                    return new Deserializer<>(annotation, deserializer);
+                } catch (InvocationTargetException | InstantiationException | IllegalAccessException | NoSuchMethodException e) {
+                    e.printStackTrace();
+                }
+            }
+            return deserializer;
+        }
+
+        private static class Deserializer<T> extends StdDeserializer<T> implements ResolvableDeserializer {
+
+            private final ValueDeserializer<T> deserializer;
+            private final JsonDeserializer<T> defaultDeserializer;
+
+            protected Deserializer(OptionalValueDeserializer reference, JsonDeserializer<T> defaultSerializer) throws InvocationTargetException, InstantiationException, IllegalAccessException, NoSuchMethodException {
+                super(defaultSerializer.handledType());
+                Class<T> genericType = (Class<T>) defaultSerializer.handledType();
+                this.defaultDeserializer = defaultSerializer;
+                ValueDeserializer<?> constructedDeserializer = reference.deserializer().getDeclaredConstructor().newInstance();
+                if (genericType.isAssignableFrom(constructedDeserializer.getType())) {
+                    this.deserializer = (ValueDeserializer<T>) constructedDeserializer;
+                } else {
+                    throw new IllegalArgumentException("ValueDeserializer of type \"" + constructedDeserializer.getType().getName() + "\" cannot construct type \"" + genericType.getName() + "\"");
+                }
+            }
+
+            @Override
+            public T deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JsonProcessingException {
+                if (p.isExpectedStartObjectToken()) {
+                    return defaultDeserializer.deserialize(p, ctxt);
+                }
+                return deserializer.deserialize(p, ctxt);
+            }
+
+            @Override
+            public void resolve(DeserializationContext ctxt) throws JsonMappingException {
+                if (defaultDeserializer instanceof ResolvableDeserializer resolvableDeserializer) {
+                    resolvableDeserializer.resolve(ctxt);
+                }
+            }
+
+            @Override
+            public Object deserializeWithType(JsonParser p, DeserializationContext ctxt, TypeDeserializer typeDeserializer) throws IOException {
+                if (p.isExpectedStartObjectToken()) {
+                    return defaultDeserializer.deserializeWithType(p, ctxt, typeDeserializer);
+                }
+                return deserializer.deserialize(p, ctxt);
+            }
+
+        }
+
+    }
+
+}

--- a/core/src/main/java/me/wolfyscript/utilities/util/json/jackson/annotations/OptionalValueSerializer.java
+++ b/core/src/main/java/me/wolfyscript/utilities/util/json/jackson/annotations/OptionalValueSerializer.java
@@ -1,0 +1,92 @@
+/*
+ *       WolfyUtilities, APIs and Utilities for Minecraft Spigot plugins
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package me.wolfyscript.utilities.util.json.jackson.annotations;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.BeanDescription;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializationConfig;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.BeanSerializerModifier;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import me.wolfyscript.utilities.util.Keyed;
+import me.wolfyscript.utilities.util.json.jackson.ValueSerializer;
+
+import java.io.IOException;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.reflect.InvocationTargetException;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface OptionalValueSerializer {
+
+    Class<? extends ValueSerializer<?>> serializer();
+
+    final class SerializerModifier extends BeanSerializerModifier {
+
+        @Override
+        public JsonSerializer<?> modifySerializer(SerializationConfig config, BeanDescription beanDesc, JsonSerializer<?> serializer) {
+            var handledType = serializer.handledType();
+            var annotation = handledType.getAnnotation(OptionalValueSerializer.class);
+            if (annotation != null) {
+                try {
+                    return new Serializer<>(annotation, (JsonSerializer<? extends Keyed>) serializer);
+                } catch (NoSuchMethodException | InvocationTargetException | InstantiationException | IllegalAccessException e) {
+                    e.printStackTrace();
+                }
+            }
+            return serializer;
+        }
+
+        private static class Serializer<T extends Keyed> extends StdSerializer<T> {
+
+            private final Class<T> genericType;
+            private final ValueSerializer<T> serializer;
+            private final JsonSerializer<T> defaultSerializer;
+
+            protected Serializer(OptionalValueSerializer reference, JsonSerializer<T> defaultSerializer) throws NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException {
+                super(defaultSerializer.handledType());
+                this.genericType = defaultSerializer.handledType();
+                this.defaultSerializer = defaultSerializer;
+
+                ValueSerializer<?> constructedDeserializer = reference.serializer().getDeclaredConstructor().newInstance();
+                if (genericType.isAssignableFrom(constructedDeserializer.getType())) {
+                    this.serializer = (ValueSerializer<T>) constructedDeserializer;
+                } else {
+                    throw new IllegalArgumentException("ValueSerializer of type \"" + constructedDeserializer.getType().getName() + "\" cannot handle type \"" + genericType.getName() + "\"");
+                }
+            }
+
+            @Override
+            public void serialize(T targetObject, JsonGenerator generator, SerializerProvider provider) throws IOException {
+                if(!serializer.serialize(targetObject, generator, provider)) {
+                    defaultSerializer.serialize(targetObject, generator, provider);
+                }
+            }
+
+        }
+
+    }
+
+
+
+}

--- a/wolfyutilities/src/main/java/me/wolfyscript/utilities/main/WUPlugin.java
+++ b/wolfyutilities/src/main/java/me/wolfyscript/utilities/main/WUPlugin.java
@@ -74,10 +74,13 @@ import me.wolfyscript.utilities.main.listeners.custom_item.CustomParticleListene
 import me.wolfyscript.utilities.main.messages.MessageFactory;
 import me.wolfyscript.utilities.main.messages.MessageHandler;
 import me.wolfyscript.utilities.util.entity.PlayerUtils;
+import me.wolfyscript.utilities.util.eval.operators.ComparisonOperatorNotEqual;
 import me.wolfyscript.utilities.util.inventory.CreativeModeTab;
 import me.wolfyscript.utilities.util.json.jackson.JacksonUtil;
 import me.wolfyscript.utilities.util.json.jackson.KeyedTypeIdResolver;
 import me.wolfyscript.utilities.util.json.jackson.annotations.OptionalKeyReference;
+import me.wolfyscript.utilities.util.json.jackson.annotations.OptionalValueDeserializer;
+import me.wolfyscript.utilities.util.json.jackson.annotations.OptionalValueSerializer;
 import me.wolfyscript.utilities.util.json.jackson.serialization.APIReferenceSerialization;
 import me.wolfyscript.utilities.util.json.jackson.serialization.ColorSerialization;
 import me.wolfyscript.utilities.util.json.jackson.serialization.DustOptionsSerialization;
@@ -219,10 +222,14 @@ public final class WUPlugin extends WolfyUtilCore {
         APIReferenceSerialization.create(module);
         JacksonUtil.registerModule(module);
 
-        var beanModifiers = new SimpleModule();
-        beanModifiers.setSerializerModifier(new OptionalKeyReference.SerializerModifier());
-        beanModifiers.setDeserializerModifier(new OptionalKeyReference.DeserializerModifier());
-        JacksonUtil.registerModule(beanModifiers);
+        var keyReferenceModule = new SimpleModule();
+        keyReferenceModule.setSerializerModifier(new OptionalKeyReference.SerializerModifier());
+        keyReferenceModule.setDeserializerModifier(new OptionalKeyReference.DeserializerModifier());
+        var valueReferenceModule = new SimpleModule();
+        valueReferenceModule.setSerializerModifier(new OptionalValueSerializer.SerializerModifier());
+        valueReferenceModule.setDeserializerModifier(new OptionalValueDeserializer.DeserializerModifier());
+        JacksonUtil.registerModule(keyReferenceModule);
+        JacksonUtil.registerModule(valueReferenceModule);
 
         //Register custom item data
 

--- a/wolfyutilities/src/main/java/me/wolfyscript/utilities/main/WUPlugin.java
+++ b/wolfyutilities/src/main/java/me/wolfyscript/utilities/main/WUPlugin.java
@@ -290,6 +290,7 @@ public final class WUPlugin extends WolfyUtilCore {
 
         var operators = getRegistries().getOperators();
         operators.register(ComparisonOperatorEqual.KEY, ComparisonOperatorEqual.class);
+        operators.register(ComparisonOperatorNotEqual.KEY, ComparisonOperatorNotEqual.class);
         operators.register(ComparisonOperatorGreater.KEY, ComparisonOperatorGreater.class);
         operators.register(ComparisonOperatorGreaterEqual.KEY, ComparisonOperatorGreaterEqual.class);
         operators.register(ComparisonOperatorLess.KEY, ComparisonOperatorLess.class);


### PR DESCRIPTION
Constant ValueProviders can be easily specified in JSON without having to use the object and key.  

Before: 
```json5
"an_integer_value": {
    "key": "wolfyutilities:int/const",
    "value": 64
}
```
New method:
```json5
"an_integer_value": "64i"
```

You can use the following postfixes:
- `i` or `I`: integer constant
- `f` or `F`: float constant
- in case the above fail it simply creates a String constant.

### Other changes:
- Added missing ComparisonOperatorNotEqual to registry.