### PR TITLE
ItemsAdder CustomStack wrapper

### DIFF
--- a/core/src/main/java/me/wolfyscript/utilities/compatibility/plugins/itemsadder/CustomStack.java
+++ b/core/src/main/java/me/wolfyscript/utilities/compatibility/plugins/itemsadder/CustomStack.java
@@ -16,17 +16,40 @@
  *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package me.wolfyscript.utilities.compatibility.plugins;
+package me.wolfyscript.utilities.compatibility.plugins.itemsadder;
 
-import me.wolfyscript.utilities.compatibility.PluginIntegration;
-import me.wolfyscript.utilities.compatibility.plugins.itemsadder.CustomStack;
 import org.bukkit.inventory.ItemStack;
 
-public interface ItemsAdderIntegration extends PluginIntegration {
+public interface CustomStack {
 
-    String KEY = "ItemsAdder";
+    ItemStack getItemStack();
 
-    CustomStack getByItemStack(ItemStack itemStack);
+    String getNamespace();
 
-    CustomStack getInstance(String namespacedID);
+    String getId();
+
+    String getNamespacedID();
+
+    String getPermission();
+
+    boolean hasPermission();
+
+    boolean isBlockAllEnchants();
+
+    boolean hasUsagesAttribute();
+
+    void setUsages(int amount);
+
+    void reduceUsages(int amount);
+
+    int getUsages();
+
+    boolean hasCustomDurability();
+
+    int getDurability();
+
+    void setDurability(int durability);
+
+    int getMaxDurability();
+
 }

--- a/plugin-compatibility-module/itemsadder/src/main/java/me/wolfyscript/utilities/compatibility/plugins/ItemsAdderImpl.java
+++ b/plugin-compatibility-module/itemsadder/src/main/java/me/wolfyscript/utilities/compatibility/plugins/ItemsAdderImpl.java
@@ -23,10 +23,13 @@ import me.wolfyscript.utilities.annotations.WUPluginIntegration;
 import me.wolfyscript.utilities.api.WolfyUtilCore;
 import me.wolfyscript.utilities.api.inventory.custom_items.references.APIReference;
 import me.wolfyscript.utilities.compatibility.PluginIntegrationAbstract;
+import me.wolfyscript.utilities.compatibility.plugins.itemsadder.CustomStack;
+import me.wolfyscript.utilities.compatibility.plugins.itemsadder.CustomStackWrapper;
 import me.wolfyscript.utilities.compatibility.plugins.itemsadder.ItemsAdderRefImpl;
 import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.Plugin;
 
 @WUPluginIntegration(pluginName = ItemsAdderIntegration.KEY)
@@ -59,4 +62,13 @@ public class ItemsAdderImpl extends PluginIntegrationAbstract implements ItemsAd
         }
     }
 
+    @Override
+    public CustomStack getByItemStack(ItemStack itemStack) {
+        return new CustomStackWrapper(dev.lone.itemsadder.api.CustomStack.byItemStack(itemStack));
+    }
+
+    @Override
+    public CustomStack getInstance(String namespacedID) {
+        return new CustomStackWrapper(dev.lone.itemsadder.api.CustomStack.getInstance(namespacedID));
+    }
 }

--- a/plugin-compatibility-module/itemsadder/src/main/java/me/wolfyscript/utilities/compatibility/plugins/itemsadder/CustomStackWrapper.java
+++ b/plugin-compatibility-module/itemsadder/src/main/java/me/wolfyscript/utilities/compatibility/plugins/itemsadder/CustomStackWrapper.java
@@ -1,0 +1,106 @@
+/*
+ *       WolfyUtilities, APIs and Utilities for Minecraft Spigot plugins
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package me.wolfyscript.utilities.compatibility.plugins.itemsadder;
+
+import org.bukkit.inventory.ItemStack;
+import dev.lone.itemsadder.api.CustomStack;
+
+public class CustomStackWrapper implements me.wolfyscript.utilities.compatibility.plugins.itemsadder.CustomStack {
+
+    private final CustomStack item;
+
+    public CustomStackWrapper(CustomStack item) {
+        this.item = item;
+    }
+
+    @Override
+    public ItemStack getItemStack() {
+        return item.getItemStack();
+    }
+
+    @Override
+    public String getNamespace() {
+        return item.getNamespace();
+    }
+
+    @Override
+    public String getId() {
+        return item.getId();
+    }
+
+    @Override
+    public String getNamespacedID() {
+        return item.getNamespacedID();
+    }
+
+    @Override
+    public String getPermission() {
+        return item.getPermission();
+    }
+
+    @Override
+    public boolean hasPermission() {
+        return item.hasPermission();
+    }
+
+    @Override
+    public boolean isBlockAllEnchants() {
+        return item.isBlockAllEnchants();
+    }
+
+    @Override
+    public boolean hasUsagesAttribute() {
+        return item.hasUsagesAttribute();
+    }
+
+    @Override
+    public void setUsages(int amount) {
+        item.setUsages(amount);
+    }
+
+    @Override
+    public void reduceUsages(int amount) {
+        item.reduceUsages(amount);
+    }
+
+    @Override
+    public int getUsages() {
+        return item.getUsages();
+    }
+
+    @Override
+    public boolean hasCustomDurability() {
+        return item.hasCustomDurability();
+    }
+
+    @Override
+    public int getDurability() {
+        return item.getDurability();
+    }
+
+    @Override
+    public void setDurability(int durability) {
+        item.setDurability(durability);
+    }
+
+    @Override
+    public int getMaxDurability() {
+        return item.getMaxDurability();
+    }
+}


### PR DESCRIPTION
This wrapper makes it possible to make use of the ItemsAdder CustomStack without adding the API to your build dependencies.

The wrapper can be access via the `ItemsAdderIntegration`.
`getByItemStack` and `getInstance` return a new CustomStack wrapper.

Get the integration:
```java
ItemsAdderIntegration integration = wuCore.getCompatibilityManager().getPlugins().getIntegration("ItemsAdder", ItemsAdderIntegration.class);
if (integration != null) {
    //ItemsAdder is available
}
```
or
```java
wuCore.getCompatibilityManager().getPlugins().runIfAvailable("ItemsAdder", ItemsAdderIntegration.class, integration -> {
    //ItemsAdder is available
    //use the integration e.g. integration.getByItemStack(itemstack); 
    //of course you need to use Atomics to edit variables outside of this lambda.
});
```