### PR TITLE
Eco items are not correctly compared in recipes

### DIFF
--- a/plugin-compatibility-module/eco/src/main/java/me/wolfyscript/utilities/compatibility/plugins/eco/EcoRefImpl.java
+++ b/plugin-compatibility-module/eco/src/main/java/me/wolfyscript/utilities/compatibility/plugins/eco/EcoRefImpl.java
@@ -29,6 +29,7 @@ import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
+import java.util.Objects;
 
 public class EcoRefImpl extends APIReference implements EcoRef {
 
@@ -51,7 +52,8 @@ public class EcoRefImpl extends APIReference implements EcoRef {
 
     @Override
     public boolean isValidItem(ItemStack itemStack) {
-        return Items.isCustomItem(itemStack);
+        var item = Items.getCustomItem(itemStack);
+        return item != null && Objects.equals(itemKey, item.getKey());
     }
 
     @Override


### PR DESCRIPTION
Fixes an issue in which items from eco are used in recipes, the check doesn't correctly compare the items, causing all eco items to be valid.