### PR TITLE
Better Language TagResolver Management

### DIFF
--- a/src/main/java/me/wolfyscript/utilities/api/language/LanguageAPI.java
+++ b/src/main/java/me/wolfyscript/utilities/api/language/LanguageAPI.java
@@ -123,29 +123,49 @@ public abstract class LanguageAPI {
     }
 
     public Component getComponent(String key, boolean translateLegacyColor) {
-        return getComponent(key, translateLegacyColor, List.of());
+        return getNode(key).getComponent(translateLegacyColor);
     }
 
-    public Component getComponent(String key, List<? extends TagResolver> resolvers) {
+    public Component getComponent(String key, TagResolver... resolvers) {
         return getComponent(key, false, resolvers);
     }
 
+    public Component getComponent(String key, boolean translateLegacyColor, TagResolver... resolvers) {
+        return getNode(key).getComponent(translateLegacyColor, resolvers);
+    }
+
+    @Deprecated
     public Component getComponent(String key, boolean translateLegacyColor, List<? extends TagResolver> resolvers) {
         return getNode(key).getComponent(translateLegacyColor, resolvers);
     }
 
+    @Deprecated
+    public Component getComponent(String key, List<? extends TagResolver> resolvers) {
+        return getComponent(key, false, resolvers);
+    }
+
     public List<Component> getComponents(String key) {
-        return getComponents(key, false, List.of());
+        return getComponents(key, false);
     }
 
     public List<Component> getComponents(String key, boolean translateLegacyColor) {
-        return getComponents(key, translateLegacyColor, List.of());
+        return getNode(key).getComponents(translateLegacyColor);
     }
 
+    public List<Component> getComponents(String key, TagResolver... resolvers) {
+        return getComponents(key, false, resolvers);
+    }
+
+    public List<Component> getComponents(String key, boolean translateLegacyColor, TagResolver... resolvers) {
+        return getNode(key).getComponents(translateLegacyColor, resolvers);
+    }
+
+    @Deprecated
     public List<Component> getComponents(String key, List<? extends TagResolver> resolvers) {
         return getComponents(key, false, resolvers);
     }
 
+    @Deprecated
     public List<Component> getComponents(String key, boolean translateLegacyColor, List<? extends TagResolver> resolvers) {
         return getNode(key).getComponents(translateLegacyColor, resolvers);
     }

--- a/src/main/java/me/wolfyscript/utilities/api/language/LanguageNode.java
+++ b/src/main/java/me/wolfyscript/utilities/api/language/LanguageNode.java
@@ -36,9 +36,29 @@ public abstract class LanguageNode {
         this.value = value;
     }
 
-    abstract public Component getComponent(boolean translateLegacyColor, List<? extends TagResolver> templates);
+    abstract public Component getComponent(boolean translateLegacyColor);
 
-    abstract public List<Component> getComponents(boolean translateLegacyColor, List<? extends TagResolver> templates);
+    abstract public Component getComponent(boolean translateLegacyColor, TagResolver tagResolver);
+
+    public Component getComponent(boolean translateLegacyColor, TagResolver... tagResolvers) {
+        return getComponent(translateLegacyColor, TagResolver.resolver(tagResolvers));
+    }
+
+    public Component getComponent(boolean translateLegacyColor, List<? extends TagResolver> tagResolvers) {
+        return getComponent(translateLegacyColor, tagResolvers.toArray(new TagResolver[0]));
+    }
+
+    abstract public List<Component> getComponents(boolean translateLegacyColor);
+
+    abstract public List<Component> getComponents(boolean translateLegacyColor, TagResolver tagResolver);
+
+    public List<Component> getComponents(boolean translateLegacyColor, TagResolver... tagResolvers) {
+        return getComponents(translateLegacyColor, TagResolver.resolver(tagResolvers));
+    }
+
+    public List<Component> getComponents(boolean translateLegacyColor, List<? extends TagResolver> tagResolvers) {
+        return getComponents(translateLegacyColor, tagResolvers.toArray(new TagResolver[0]));
+    }
 
     abstract public String getRaw();
 

--- a/src/main/java/me/wolfyscript/utilities/api/language/LanguageNodeArray.java
+++ b/src/main/java/me/wolfyscript/utilities/api/language/LanguageNodeArray.java
@@ -50,17 +50,31 @@ public class LanguageNodeArray extends LanguageNode {
     }
 
     @Override
-    public Component getComponent(boolean translateLegacyColor, List<? extends TagResolver> templates) {
-        return chat.getMiniMessage().deserialize(translateLegacyColor ? rawLegacyLine : rawLine, templates.toArray(TagResolver[]::new));
+    public Component getComponent(boolean translateLegacyColor) {
+        return chat.getMiniMessage().deserialize(translateLegacyColor ? rawLegacyLine : rawLine);
     }
 
     @Override
-    public List<Component> getComponents(boolean translateLegacyColor, List<? extends TagResolver> templates) {
-        return translateLegacyColor ? getComponents(rawLegacy, templates) : getComponents(raw, templates);
+    public Component getComponent(boolean translateLegacyColor, TagResolver tagResolver) {
+        return chat.getMiniMessage().deserialize(translateLegacyColor ? rawLegacyLine : rawLine, tagResolver);
     }
 
-    private List<Component> getComponents(List<String> rawValues, List<? extends TagResolver> templates) {
-        return rawValues.stream().map(s -> chat.getMiniMessage().deserialize(s, templates.toArray(TagResolver[]::new))).collect(Collectors.toList());
+    @Override
+    public List<Component> getComponents(boolean translateLegacyColor) {
+        return getComponents(translateLegacyColor ? rawLegacy : raw);
+    }
+
+    @Override
+    public List<Component> getComponents(boolean translateLegacyColor, TagResolver tagResolver) {
+        return getComponents(translateLegacyColor ? rawLegacy : raw, tagResolver);
+    }
+
+    private List<Component> getComponents(List<String> rawValues) {
+        return rawValues.stream().map(s -> chat.getMiniMessage().deserialize(s)).collect(Collectors.toList());
+    }
+
+    private List<Component> getComponents(List<String> rawValues, TagResolver tagResolver) {
+        return rawValues.stream().map(s -> chat.getMiniMessage().deserialize(s, tagResolver)).collect(Collectors.toList());
     }
 
     @Override

--- a/src/main/java/me/wolfyscript/utilities/api/language/LanguageNodeMissing.java
+++ b/src/main/java/me/wolfyscript/utilities/api/language/LanguageNodeMissing.java
@@ -32,12 +32,22 @@ public class LanguageNodeMissing extends LanguageNode {
     }
 
     @Override
-    public Component getComponent(boolean translateLegacyColor, List<? extends TagResolver> templates) {
+    public Component getComponent(boolean translateLegacyColor) {
         return Component.empty();
     }
 
     @Override
-    public List<Component> getComponents(boolean translateLegacyColor, List<? extends TagResolver> templates) {
+    public Component getComponent(boolean translateLegacyColor, TagResolver tagResolver) {
+        return Component.empty();
+    }
+
+    @Override
+    public List<Component> getComponents(boolean translateLegacyColor) {
+        return List.of();
+    }
+
+    @Override
+    public List<Component> getComponents(boolean translateLegacyColor, TagResolver tagResolver) {
         return List.of();
     }
 

--- a/src/main/java/me/wolfyscript/utilities/api/language/LanguageNodeText.java
+++ b/src/main/java/me/wolfyscript/utilities/api/language/LanguageNodeText.java
@@ -37,13 +37,27 @@ public class LanguageNodeText extends LanguageNode {
     }
 
     @Override
-    public Component getComponent(boolean translateLegacyColor, List<? extends TagResolver> templates) {
-        return chat.getMiniMessage().deserialize(translateLegacyColor ? rawLegacy : raw, templates.toArray(TagResolver[]::new));
+    public Component getComponent(boolean translateLegacyColor) {
+        return chat.getMiniMessage().deserialize(getText(translateLegacyColor));
     }
 
     @Override
-    public List<Component> getComponents(boolean translateLegacyColor, List<? extends TagResolver> templates) {
-        return List.of(chat.getMiniMessage().deserialize(translateLegacyColor ? rawLegacy : raw, templates.toArray(TagResolver[]::new)));
+    public Component getComponent(boolean translateLegacyColor, TagResolver tagResolver) {
+        return chat.getMiniMessage().deserialize(getText(translateLegacyColor), tagResolver);
+    }
+
+    @Override
+    public List<Component> getComponents(boolean translateLegacyColor) {
+        return List.of(chat.getMiniMessage().deserialize(getText(translateLegacyColor)));
+    }
+
+    @Override
+    public List<Component> getComponents(boolean translateLegacyColor, TagResolver tagResolver) {
+        return List.of(chat.getMiniMessage().deserialize(getText(translateLegacyColor), tagResolver));
+    }
+
+    private String getText(boolean translateLegacyColor) {
+        return translateLegacyColor ? rawLegacy : raw;
     }
 
     @Override


### PR DESCRIPTION
Added TagResolver Array params to LanguageAPI and LanguageNodes component methods.
These methods are also the preferred way to use tag resolvers, as they don't need to convert between list and array.