### PR TITLE
Better Configuration of MiniMessage format in Languages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,15 @@
     </dependencies>
 
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/java</directory>
+                <includes>
+                    <include>**/*.java</include>
+                    <include>**/*.gwt.xml</include>
+                </includes>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/com/wolfyscript/utilities/common/chat/Chat.java
+++ b/src/main/java/com/wolfyscript/utilities/common/chat/Chat.java
@@ -150,10 +150,35 @@ public abstract class Chat {
      * If it is not available it returns an empty component.
      *
      * @param key The key in the language.
+     * @param resolvers The custom tag resolvers to use.
+     * @return The component set for the key; empty component if not available.
+     */
+    public abstract Component translated(String key, TagResolver... resolvers);
+
+    /**
+     * Creates a {@link Component} of the specified language key.<br>
+     * If the key exists in the language it will be translated and returns the according component.
+     * If it is not available it returns an empty component.
+     *
+     * @param key The key in the language.
+     * @param resolver The custom tag resolver to use.
+     * @return The component set for the key; empty component if not available.
+     */
+    public abstract Component translated(String key, TagResolver resolver);
+
+    /**
+     * Creates a {@link Component} of the specified language key.<br>
+     * If the key exists in the language it will be translated and returns the according component.
+     * If it is not available it returns an empty component.
+     *
+     * @param key The key in the language.
      * @param translateLegacyColor If it should translate legacy '&' color codes.
      * @return The component set for the key; empty component if not available.
      */
-    public abstract Component translated(String key, boolean translateLegacyColor);
+    @Deprecated
+    public Component translated(String key, boolean translateLegacyColor) {
+        return translated(key);
+    }
 
     /**
      * Creates a {@link Component} of the specified language key.<br>
@@ -164,7 +189,10 @@ public abstract class Chat {
      * @param resolvers The custom tag resolvers to use.
      * @return The component set for the key; empty component if not available.
      */
-    public abstract Component translated(String key, List<? extends TagResolver> resolvers);
+    @Deprecated
+    public Component translated(String key, List<? extends TagResolver> resolvers) {
+        return translated(key, resolvers.toArray(new TagResolver[0]));
+    }
 
     /**
      * Creates a {@link Component} of the specified language key.<br>
@@ -176,7 +204,10 @@ public abstract class Chat {
      * @param translateLegacyColor If it should translate legacy '&' color codes.
      * @return The component set for the key; empty component if not available.
      */
-    public abstract Component translated(String key, boolean translateLegacyColor, List<? extends TagResolver> resolvers);
+    @Deprecated
+    public Component translated(String key, boolean translateLegacyColor, List<? extends TagResolver> resolvers) {
+        return translated(key, resolvers.toArray(new TagResolver[0]));
+    }
 
     /**
      * Creates a ClickEvent, that executes code when clicked.<br>

--- a/src/main/java/me/wolfyscript/utilities/api/language/Language.java
+++ b/src/main/java/me/wolfyscript/utilities/api/language/Language.java
@@ -73,13 +73,7 @@ public class Language {
     private void setValues(String fieldName, JsonNode value) {
         switch (type) {
             case NESTED -> readNestedNode(fieldName, value);
-            case FLAT -> {
-                if (value.isArray()) {
-                    mappedLangNodes.put(fieldName, new LanguageNodeArray(api.getChat(), value));
-                } else {
-                    mappedLangNodes.put(fieldName, new LanguageNodeText(api.getChat(), value));
-                }
-            }
+            case FLAT -> registerNode(fieldName, value);
             default -> { /* Not going to happen */ }
         }
     }
@@ -96,13 +90,19 @@ public class Language {
         return mappedLangNodes;
     }
 
+    private void registerNode(String path, JsonNode node) {
+        if (node.isArray()) {
+            mappedLangNodes.put(path, new LanguageNodeArray(this, api.getChat(), node));
+        } else {
+            mappedLangNodes.put(path, new LanguageNodeText(this, api.getChat(), node));
+        }
+    }
+
     private void readNestedNode(String path, JsonNode node) {
         if (node.isObject()) {
             node.fields().forEachRemaining(entry -> readNestedNode(path + "." + entry.getKey(), entry.getValue()));
-        } else if (node.isArray()) {
-            mappedLangNodes.put(path, new LanguageNodeArray(api.getChat(), node));
         } else {
-            mappedLangNodes.put(path, new LanguageNodeText(api.getChat(), node));
+            registerNode(path, node);
         }
     }
 
@@ -135,7 +135,7 @@ public class Language {
 
     @NotNull
     public LanguageNode getNode(String path) {
-        return mappedLangNodes.computeIfAbsent(path, s -> new LanguageNodeMissing(api.getChat()));
+        return mappedLangNodes.computeIfAbsent(path, s -> new LanguageNodeMissing(this, api.getChat()));
     }
 
     @NotNull

--- a/src/main/java/me/wolfyscript/utilities/api/language/Language.java
+++ b/src/main/java/me/wolfyscript/utilities/api/language/Language.java
@@ -51,6 +51,8 @@ public class Language {
     private final String lang;
     @JsonInclude(JsonInclude.Include.NON_DEFAULT)
     private final Type type = Type.NESTED;
+    @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+    private final boolean useMiniMessageFormat = false;
     private final Map<String, LanguageNode> mappedLangNodes = new ConcurrentHashMap<>();
 
     /**
@@ -139,6 +141,10 @@ public class Language {
     @NotNull
     public JsonNode getNodeAt(String path) {
         return getNode(path).getValue();
+    }
+
+    public boolean usesMiniMessageFormat() {
+        return useMiniMessageFormat;
     }
 
     /**

--- a/src/main/java/me/wolfyscript/utilities/api/language/LanguageAPI.java
+++ b/src/main/java/me/wolfyscript/utilities/api/language/LanguageAPI.java
@@ -118,20 +118,39 @@ public abstract class LanguageAPI {
         return node;
     }
 
+    /**
+     * Retrieves the Component of the specified key from the active language.<br>
+     * In case the key cannot be found in the active language, it retrieves it from the fallback language, if available.<br>
+     * Otherwise, returns an empty Component.
+     *
+     * @param key The key to the text in the language.
+     * @return The Component of the key, or an empty Component if not found.
+     */
     public Component getComponent(String key) {
-        return getComponent(key, false, List.of());
+        return getNode(key).getComponent();
     }
 
-    public Component getComponent(String key, boolean translateLegacyColor) {
-        return getNode(key).getComponent(translateLegacyColor);
-    }
-
+    /**
+     * Retrieves the Component of the specified key from the active language.<br>
+     * In case the key cannot be found in the active language, it retrieves it from the fallback language, if available.<br>
+     * Otherwise, returns an empty Component.<br>
+     * The TagResolvers can be used to handle custom tags the component might need.
+     *
+     * @param key The key to the text in the language.
+     * @return The Component of the key, or an empty Component if not found.
+     */
     public Component getComponent(String key, TagResolver... resolvers) {
-        return getComponent(key, false, resolvers);
+        return getNode(key).getComponent(resolvers);
     }
 
+    @Deprecated
+    public Component getComponent(String key, boolean translateLegacyColor) {
+        return getNode(key).getComponent();
+    }
+
+    @Deprecated
     public Component getComponent(String key, boolean translateLegacyColor, TagResolver... resolvers) {
-        return getNode(key).getComponent(translateLegacyColor, resolvers);
+        return getNode(key).getComponent(resolvers);
     }
 
     @Deprecated
@@ -144,20 +163,39 @@ public abstract class LanguageAPI {
         return getComponent(key, false, resolvers);
     }
 
+    /**
+     * Retrieves the Components of the specified key from the active language.<br>
+     * In case the key cannot be found in the active language, it retrieves it from the fallback language, if available.<br>
+     * Otherwise, returns an empty List.
+     *
+     * @param key The key to the text in the language.
+     * @return The Component of the key, or an empty List if not found.
+     */
     public List<Component> getComponents(String key) {
-        return getComponents(key, false);
+        return getNode(key).getComponents();
     }
 
-    public List<Component> getComponents(String key, boolean translateLegacyColor) {
-        return getNode(key).getComponents(translateLegacyColor);
-    }
-
+    /**
+     * Retrieves the Components of the specified key from the active language.<br>
+     * In case the key cannot be found in the active language, it retrieves it from the fallback language, if available.<br>
+     * Otherwise, returns an empty List.<br>
+     * The TagResolvers can be used to handle custom tags the components might need.
+     *
+     * @param key The key to the text in the language.
+     * @return The Component of the key, or an empty List if not found.
+     */
     public List<Component> getComponents(String key, TagResolver... resolvers) {
-        return getComponents(key, false, resolvers);
+        return getNode(key).getComponents(resolvers);
     }
 
+    @Deprecated
+    public List<Component> getComponents(String key, boolean translateLegacyColor) {
+        return getNode(key).getComponents();
+    }
+
+    @Deprecated
     public List<Component> getComponents(String key, boolean translateLegacyColor, TagResolver... resolvers) {
-        return getNode(key).getComponents(translateLegacyColor, resolvers);
+        return getNode(key).getComponents(resolvers);
     }
 
     @Deprecated

--- a/src/main/java/me/wolfyscript/utilities/api/language/LanguageAPI.java
+++ b/src/main/java/me/wolfyscript/utilities/api/language/LanguageAPI.java
@@ -230,7 +230,7 @@ public abstract class LanguageAPI {
      * @param legacyText The legacy text that may include legacy color codes.
      * @return The converted text compatible with MiniMessage.
      */
-    protected abstract String convertLegacyToMiniMessage(String legacyText);
+    public abstract String convertLegacyToMiniMessage(String legacyText);
 
     @Deprecated
     public abstract List<String> replaceKeys(List<String> msg);

--- a/src/main/java/me/wolfyscript/utilities/api/language/LanguageNode.java
+++ b/src/main/java/me/wolfyscript/utilities/api/language/LanguageNode.java
@@ -29,11 +29,13 @@ import java.util.List;
 public abstract class LanguageNode {
 
     private final JsonNode value;
+    protected final Language language;
     protected Chat chat;
 
-    protected LanguageNode(Chat chat, JsonNode value) {
+    protected LanguageNode(Language language, Chat chat, JsonNode value) {
         this.chat = chat;
         this.value = value;
+        this.language = language;
     }
 
     abstract public Component getComponent(boolean translateLegacyColor);

--- a/src/main/java/me/wolfyscript/utilities/api/language/LanguageNode.java
+++ b/src/main/java/me/wolfyscript/utilities/api/language/LanguageNode.java
@@ -38,26 +38,85 @@ public abstract class LanguageNode {
         this.language = language;
     }
 
-    abstract public Component getComponent(boolean translateLegacyColor);
+    abstract public Component getComponent();
 
-    abstract public Component getComponent(boolean translateLegacyColor, TagResolver tagResolver);
+    abstract public Component getComponent(TagResolver tagResolver);
 
-    public Component getComponent(boolean translateLegacyColor, TagResolver... tagResolvers) {
-        return getComponent(translateLegacyColor, TagResolver.resolver(tagResolvers));
+    public Component getComponent(TagResolver... tagResolvers) {
+        return getComponent(TagResolver.resolver(tagResolvers));
     }
 
+    @Deprecated
+    public Component getComponent(boolean translateLegacyColor) {
+        return getComponent();
+    }
+
+    @Deprecated
+    public Component getComponent(boolean translateLegacyColor, TagResolver tagResolver) {
+        return getComponent(tagResolver);
+    }
+
+    @Deprecated
+    public Component getComponent(boolean translateLegacyColor, TagResolver... tagResolvers) {
+        return getComponent(tagResolvers);
+    }
+
+    /**
+     * @deprecated Replaced by {@link #getComponents(TagResolver)}! The translateLegacyColor has no effect anymore!
+     *  Plus, converting a list to an array is expensive! You may also use {@link #getComponent(TagResolver)} and {@link TagResolver#resolver(Iterable)}.
+     * @param translateLegacyColor translate the legacy color codes in the raw value
+     * @return The Component of this node
+     */
+    @Deprecated
     public Component getComponent(boolean translateLegacyColor, List<? extends TagResolver> tagResolvers) {
         return getComponent(translateLegacyColor, tagResolvers.toArray(new TagResolver[0]));
     }
 
-    abstract public List<Component> getComponents(boolean translateLegacyColor);
+    abstract public List<Component> getComponents();
 
-    abstract public List<Component> getComponents(boolean translateLegacyColor, TagResolver tagResolver);
+    abstract public List<Component> getComponents(TagResolver tagResolver);
 
-    public List<Component> getComponents(boolean translateLegacyColor, TagResolver... tagResolvers) {
-        return getComponents(translateLegacyColor, TagResolver.resolver(tagResolvers));
+    public List<Component> getComponents(TagResolver... tagResolvers) {
+        return getComponents(TagResolver.resolver(tagResolvers));
     }
 
+    /**
+     * @deprecated Replaced by {@link #getComponents()}! The translateLegacyColor has no effect anymore!
+     * @param translateLegacyColor translate the legacy color codes in the raw value
+     * @return The list of Components.
+     */
+    @Deprecated
+    public List<Component> getComponents(boolean translateLegacyColor) {
+        return getComponents();
+    }
+
+    /**
+     * @deprecated Replaced by {@link #getComponents(TagResolver)}! The translateLegacyColor has no effect anymore!
+     * @param translateLegacyColor translate the legacy color codes in the raw value
+     * @return The list of Components.
+     */
+    @Deprecated
+    public List<Component> getComponents(boolean translateLegacyColor, TagResolver tagResolver) {
+        return getComponents(tagResolver);
+    }
+
+    /**
+     * @deprecated Replaced by {@link #getComponents(TagResolver...)}! The translateLegacyColor has no effect anymore!
+     * @param translateLegacyColor translate the legacy color codes in the raw value
+     * @return The list of Components.
+     */
+    @Deprecated
+    public List<Component> getComponents(boolean translateLegacyColor, TagResolver... tagResolvers) {
+        return getComponents(tagResolvers);
+    }
+
+    /**
+     * @deprecated Replaced by {@link #getComponents(TagResolver...)}! The translateLegacyColor has no effect anymore!
+     *  Plus, converting a list to an array is expensive! You may also use {@link #getComponent(TagResolver)} and {@link TagResolver#resolver(Iterable)}.
+     * @param translateLegacyColor translate the legacy color codes in the raw value
+     * @return The list of Components.
+     */
+    @Deprecated
     public List<Component> getComponents(boolean translateLegacyColor, List<? extends TagResolver> tagResolvers) {
         return getComponents(translateLegacyColor, tagResolvers.toArray(new TagResolver[0]));
     }

--- a/src/main/java/me/wolfyscript/utilities/api/language/LanguageNodeArray.java
+++ b/src/main/java/me/wolfyscript/utilities/api/language/LanguageNodeArray.java
@@ -45,22 +45,22 @@ public class LanguageNodeArray extends LanguageNode {
     }
 
     @Override
-    public Component getComponent(boolean translateLegacyColor) {
+    public Component getComponent() {
         return chat.getMiniMessage().deserialize(rawLine);
     }
 
     @Override
-    public Component getComponent(boolean translateLegacyColor, TagResolver tagResolver) {
+    public Component getComponent(TagResolver tagResolver) {
         return chat.getMiniMessage().deserialize(rawLine, tagResolver);
     }
 
     @Override
-    public List<Component> getComponents(boolean translateLegacyColor) {
+    public List<Component> getComponents() {
         return getComponents(raw);
     }
 
     @Override
-    public List<Component> getComponents(boolean translateLegacyColor, TagResolver tagResolver) {
+    public List<Component> getComponents(TagResolver tagResolver) {
         return getComponents(raw, tagResolver);
     }
 

--- a/src/main/java/me/wolfyscript/utilities/api/language/LanguageNodeArray.java
+++ b/src/main/java/me/wolfyscript/utilities/api/language/LanguageNodeArray.java
@@ -31,42 +31,37 @@ import java.util.stream.Collectors;
 public class LanguageNodeArray extends LanguageNode {
 
     private final List<String> raw;
-    private final List<String> rawLegacy;
     private final String rawLine;
-    private final String rawLegacyLine;
 
     LanguageNodeArray(Language language, Chat chat, JsonNode jsonNode) {
         super(language, chat, jsonNode);
         this.raw = new LinkedList<>();
-        this.rawLegacy = new LinkedList<>();
         Iterator<JsonNode> nodeItr = jsonNode.elements();
         while (nodeItr.hasNext()) {
             String value = nodeItr.next().textValue();
-            this.raw.add(value);
-            this.rawLegacy.add(chat.getWolfyUtils().getLanguageAPI().convertLegacyToMiniMessage(value));
+            this.raw.add(language.usesMiniMessageFormat() ? value : chat.getWolfyUtils().getLanguageAPI().convertLegacyToMiniMessage(value));
         }
         this.rawLine = raw.stream().reduce("", (s, s2) -> s + " " + s2);
-        this.rawLegacyLine = rawLegacy.stream().reduce("", (s, s2) -> s + " " + s2);
     }
 
     @Override
     public Component getComponent(boolean translateLegacyColor) {
-        return chat.getMiniMessage().deserialize(translateLegacyColor ? rawLegacyLine : rawLine);
+        return chat.getMiniMessage().deserialize(rawLine);
     }
 
     @Override
     public Component getComponent(boolean translateLegacyColor, TagResolver tagResolver) {
-        return chat.getMiniMessage().deserialize(translateLegacyColor ? rawLegacyLine : rawLine, tagResolver);
+        return chat.getMiniMessage().deserialize(rawLine, tagResolver);
     }
 
     @Override
     public List<Component> getComponents(boolean translateLegacyColor) {
-        return getComponents(translateLegacyColor ? rawLegacy : raw);
+        return getComponents(raw);
     }
 
     @Override
     public List<Component> getComponents(boolean translateLegacyColor, TagResolver tagResolver) {
-        return getComponents(translateLegacyColor ? rawLegacy : raw, tagResolver);
+        return getComponents(raw, tagResolver);
     }
 
     private List<Component> getComponents(List<String> rawValues) {

--- a/src/main/java/me/wolfyscript/utilities/api/language/LanguageNodeArray.java
+++ b/src/main/java/me/wolfyscript/utilities/api/language/LanguageNodeArray.java
@@ -35,8 +35,8 @@ public class LanguageNodeArray extends LanguageNode {
     private final String rawLine;
     private final String rawLegacyLine;
 
-    LanguageNodeArray(Chat chat, JsonNode jsonNode) {
-        super(chat, jsonNode);
+    LanguageNodeArray(Language language, Chat chat, JsonNode jsonNode) {
+        super(language, chat, jsonNode);
         this.raw = new LinkedList<>();
         this.rawLegacy = new LinkedList<>();
         Iterator<JsonNode> nodeItr = jsonNode.elements();

--- a/src/main/java/me/wolfyscript/utilities/api/language/LanguageNodeMissing.java
+++ b/src/main/java/me/wolfyscript/utilities/api/language/LanguageNodeMissing.java
@@ -27,8 +27,8 @@ import java.util.List;
 
 public class LanguageNodeMissing extends LanguageNode {
 
-    LanguageNodeMissing(Chat chat) {
-        super(chat, JsonNodeFactory.instance.missingNode());
+    LanguageNodeMissing(Language language, Chat chat) {
+        super(language, chat, JsonNodeFactory.instance.missingNode());
     }
 
     @Override

--- a/src/main/java/me/wolfyscript/utilities/api/language/LanguageNodeMissing.java
+++ b/src/main/java/me/wolfyscript/utilities/api/language/LanguageNodeMissing.java
@@ -32,22 +32,22 @@ public class LanguageNodeMissing extends LanguageNode {
     }
 
     @Override
-    public Component getComponent(boolean translateLegacyColor) {
+    public Component getComponent() {
         return Component.empty();
     }
 
     @Override
-    public Component getComponent(boolean translateLegacyColor, TagResolver tagResolver) {
+    public Component getComponent(TagResolver tagResolver) {
         return Component.empty();
     }
 
     @Override
-    public List<Component> getComponents(boolean translateLegacyColor) {
+    public List<Component> getComponents() {
         return List.of();
     }
 
     @Override
-    public List<Component> getComponents(boolean translateLegacyColor, TagResolver tagResolver) {
+    public List<Component> getComponents(TagResolver tagResolver) {
         return List.of();
     }
 

--- a/src/main/java/me/wolfyscript/utilities/api/language/LanguageNodeText.java
+++ b/src/main/java/me/wolfyscript/utilities/api/language/LanguageNodeText.java
@@ -30,10 +30,13 @@ public class LanguageNodeText extends LanguageNode {
     private final String raw;
     private final String rawLegacy;
 
-    LanguageNodeText(Chat chat, JsonNode jsonNode) {
-        super(chat, jsonNode);
-        this.raw = jsonNode.asText("");
-        this.rawLegacy = chat.getWolfyUtils().getLanguageAPI().convertLegacyToMiniMessage(raw);
+    LanguageNodeText(Language language, Chat chat, JsonNode jsonNode) {
+        super(language, chat, jsonNode);
+        if (language.usesMiniMessageFormat()) {
+            this.raw = jsonNode.asText("");
+        } else {
+            this.raw = chat.getWolfyUtils().getLanguageAPI().convertLegacyToMiniMessage(jsonNode.asText(""));
+        }
     }
 
     @Override

--- a/src/main/java/me/wolfyscript/utilities/api/language/LanguageNodeText.java
+++ b/src/main/java/me/wolfyscript/utilities/api/language/LanguageNodeText.java
@@ -28,7 +28,6 @@ import java.util.List;
 public class LanguageNodeText extends LanguageNode {
 
     private final String raw;
-    private final String rawLegacy;
 
     LanguageNodeText(Language language, Chat chat, JsonNode jsonNode) {
         super(language, chat, jsonNode);
@@ -41,26 +40,22 @@ public class LanguageNodeText extends LanguageNode {
 
     @Override
     public Component getComponent(boolean translateLegacyColor) {
-        return chat.getMiniMessage().deserialize(getText(translateLegacyColor));
+        return chat.getMiniMessage().deserialize(raw);
     }
 
     @Override
     public Component getComponent(boolean translateLegacyColor, TagResolver tagResolver) {
-        return chat.getMiniMessage().deserialize(getText(translateLegacyColor), tagResolver);
+        return chat.getMiniMessage().deserialize(raw, tagResolver);
     }
 
     @Override
     public List<Component> getComponents(boolean translateLegacyColor) {
-        return List.of(chat.getMiniMessage().deserialize(getText(translateLegacyColor)));
+        return List.of(chat.getMiniMessage().deserialize(raw));
     }
 
     @Override
     public List<Component> getComponents(boolean translateLegacyColor, TagResolver tagResolver) {
-        return List.of(chat.getMiniMessage().deserialize(getText(translateLegacyColor), tagResolver));
-    }
-
-    private String getText(boolean translateLegacyColor) {
-        return translateLegacyColor ? rawLegacy : raw;
+        return List.of(chat.getMiniMessage().deserialize(raw, tagResolver));
     }
 
     @Override

--- a/src/main/java/me/wolfyscript/utilities/api/language/LanguageNodeText.java
+++ b/src/main/java/me/wolfyscript/utilities/api/language/LanguageNodeText.java
@@ -39,22 +39,22 @@ public class LanguageNodeText extends LanguageNode {
     }
 
     @Override
-    public Component getComponent(boolean translateLegacyColor) {
+    public Component getComponent() {
         return chat.getMiniMessage().deserialize(raw);
     }
 
     @Override
-    public Component getComponent(boolean translateLegacyColor, TagResolver tagResolver) {
+    public Component getComponent(TagResolver tagResolver) {
         return chat.getMiniMessage().deserialize(raw, tagResolver);
     }
 
     @Override
-    public List<Component> getComponents(boolean translateLegacyColor) {
+    public List<Component> getComponents() {
         return List.of(chat.getMiniMessage().deserialize(raw));
     }
 
     @Override
-    public List<Component> getComponents(boolean translateLegacyColor, TagResolver tagResolver) {
+    public List<Component> getComponents(TagResolver tagResolver) {
         return List.of(chat.getMiniMessage().deserialize(raw, tagResolver));
     }
 


### PR DESCRIPTION
- Language Nodes no longer make use of the `translateLegacyColor`
- Added `useMiniMessageFormat` property to Languages
- Deprecated legacy color LanguageNode getComponent/s methods and added new abstract methods without the legacy color options.
- Made LanguageAPI#convertLegacyToMiniMessage public.
- Added source to final artifact.