### PR TITLE
Cross-Platform GUI API [v5]

### DIFF
--- a/src/main/java/com/wolfyscript/utilities/Platform.java
+++ b/src/main/java/com/wolfyscript/utilities/Platform.java
@@ -1,0 +1,27 @@
+/*
+ *       WolfyUtilities, APIs and Utilities for Minecraft Spigot plugins
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.wolfyscript.utilities;
+
+public enum Platform {
+
+    SPIGOT,
+    PAPER,
+    SPONGE
+
+}

--- a/src/main/java/com/wolfyscript/utilities/common/WolfyCore.java
+++ b/src/main/java/com/wolfyscript/utilities/common/WolfyCore.java
@@ -19,6 +19,7 @@
 package com.wolfyscript.utilities.common;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wolfyscript.utilities.Platform;
 import com.wolfyscript.utilities.common.chat.Chat;
 import com.wolfyscript.utilities.common.registry.Registries;
 import org.reflections.Reflections;
@@ -38,4 +39,6 @@ public interface WolfyCore {
     Reflections getReflections();
 
     Registries getRegistries();
+
+    Platform getPlatform();
 }

--- a/src/main/java/com/wolfyscript/utilities/common/WolfyUtils.java
+++ b/src/main/java/com/wolfyscript/utilities/common/WolfyUtils.java
@@ -20,6 +20,7 @@ package com.wolfyscript.utilities.common;
 
 import com.fasterxml.jackson.annotation.JsonIncludeProperties;
 import com.wolfyscript.utilities.common.chat.Chat;
+import com.wolfyscript.utilities.common.gui.GuiAPIManager;
 import com.wolfyscript.utilities.common.json.jackson.MapperUtil;
 import com.wolfyscript.utilities.common.registry.Registries;
 import java.util.logging.Logger;
@@ -67,6 +68,8 @@ public abstract class WolfyUtils {
     public abstract Chat getChat();
 
     public abstract Identifiers getIdentifiers();
+
+    public abstract GuiAPIManager getGUIManager();
 
     public Registries getRegistries() {
         return getCore().getRegistries();

--- a/src/main/java/com/wolfyscript/utilities/common/adapters/ItemStack.java
+++ b/src/main/java/com/wolfyscript/utilities/common/adapters/ItemStack.java
@@ -18,10 +18,33 @@
 
 package com.wolfyscript.utilities.common.adapters;
 
+import com.wolfyscript.utilities.NamespacedKey;
+import com.wolfyscript.utilities.common.items.ItemStackConfig;
+
 public interface ItemStack {
 
-    Item getItem();
+    /**
+     * The id representing the item of this ItemStack.<br>
+     * Usually e.g. <pre>minecraft:&lt;item_id&gt;</pre>
+     *
+     * @return The id of the item.
+     */
+    NamespacedKey getItem();
 
+    /**
+     * The stack amount of this ItemStack.
+     *
+     * @return The stack amount.
+     */
     int getAmount();
+
+    /**
+     * Creates a snapshot of the whole ItemStack including the full NBT.<br>
+     * <b>This can be quite resource heavy!</b><br>
+     * The snapshot can be simply written to json using the Json mapper of WolfyUtils.
+     *
+     * @return The snapshot ItemStack config of this ItemStack.
+     */
+    ItemStackConfig<?> snapshot();
 
 }

--- a/src/main/java/com/wolfyscript/utilities/common/adapters/Items.java
+++ b/src/main/java/com/wolfyscript/utilities/common/adapters/Items.java
@@ -20,6 +20,6 @@ package com.wolfyscript.utilities.common.adapters;
 
 public interface Items {
 
-    Item getItem(String key);
+
 
 }

--- a/src/main/java/com/wolfyscript/utilities/common/gui/AreaComponent.java
+++ b/src/main/java/com/wolfyscript/utilities/common/gui/AreaComponent.java
@@ -1,0 +1,23 @@
+/*
+ *       WolfyUtilities, APIs and Utilities for Minecraft Spigot plugins
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.wolfyscript.utilities.common.gui;
+
+public interface AreaComponent<D extends Data> extends SlotComponent<D> {
+
+}

--- a/src/main/java/com/wolfyscript/utilities/common/gui/ChildComponentBuilder.java
+++ b/src/main/java/com/wolfyscript/utilities/common/gui/ChildComponentBuilder.java
@@ -1,0 +1,31 @@
+/*
+ *       WolfyUtilities, APIs and Utilities for Minecraft Spigot plugins
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.wolfyscript.utilities.common.gui;
+
+import com.google.common.collect.BiMap;
+import com.wolfyscript.utilities.NamespacedKey;
+import java.util.function.Consumer;
+
+public interface ChildComponentBuilder<D extends Data> {
+
+    // TODO: This needs proper testing
+    <CT extends Component.Builder<D, ?, ?>> ChildComponentBuilder<D> custom(String subID, NamespacedKey builderId, Class<CT> builderType, Consumer<CT> builderConsumer);
+
+    BiMap<String, ? extends Component<D>> create();
+}

--- a/src/main/java/com/wolfyscript/utilities/common/gui/ClickInteractionDetails.java
+++ b/src/main/java/com/wolfyscript/utilities/common/gui/ClickInteractionDetails.java
@@ -1,6 +1,6 @@
 package com.wolfyscript.utilities.common.gui;
 
-public interface GUIClickInteractionDetails extends GUIInteractionDetails {
+public interface ClickInteractionDetails<D extends Data> extends InteractionDetails<D> {
 
     boolean isShift();
 

--- a/src/main/java/com/wolfyscript/utilities/common/gui/Cluster.java
+++ b/src/main/java/com/wolfyscript/utilities/common/gui/Cluster.java
@@ -1,0 +1,35 @@
+/*
+ *       WolfyUtilities, APIs and Utilities for Minecraft Spigot plugins
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.wolfyscript.utilities.common.gui;
+
+import java.util.Set;
+
+public interface Cluster<D extends Data> extends MenuComponent<D> {
+
+    MenuComponent<D> entry();
+
+    @Override
+    Cluster<D> parent();
+
+    @Override
+    Set<? extends MenuComponent<D>> children();
+
+    Class<D> dataType();
+
+}

--- a/src/main/java/com/wolfyscript/utilities/common/gui/ClusterChildComponentBuilder.java
+++ b/src/main/java/com/wolfyscript/utilities/common/gui/ClusterChildComponentBuilder.java
@@ -1,0 +1,32 @@
+/*
+ *       WolfyUtilities, APIs and Utilities for Minecraft Spigot plugins
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.wolfyscript.utilities.common.gui;
+
+import com.google.common.collect.BiMap;
+import java.util.function.Consumer;
+
+public interface ClusterChildComponentBuilder<D extends Data> extends ChildComponentBuilder<D> {
+
+    ClusterChildComponentBuilder<D> window(String id, Consumer<WindowComponentBuilder<D>> builderConsumer);
+
+    ClusterChildComponentBuilder<D> cluster(String id, Consumer<ClusterComponentBuilder<D>> builderConsumer);
+
+    @Override
+    BiMap<String, ? extends MenuComponent<D>> create();
+}

--- a/src/main/java/com/wolfyscript/utilities/common/gui/ClusterCommonImpl.java
+++ b/src/main/java/com/wolfyscript/utilities/common/gui/ClusterCommonImpl.java
@@ -104,7 +104,7 @@ public abstract class ClusterCommonImpl<D extends Data> implements Cluster<D> {
 
     @Override
     public ComponentState<D> getState(GuiHolder<D> holder) {
-        return states[stateSelector.run(holder, holder.getHandler().getData(), this)];
+        return states[stateSelector.run(holder, holder.getViewManager().getData(), this)];
     }
 
     @Override

--- a/src/main/java/com/wolfyscript/utilities/common/gui/ClusterCommonImpl.java
+++ b/src/main/java/com/wolfyscript/utilities/common/gui/ClusterCommonImpl.java
@@ -1,0 +1,231 @@
+/*
+ *       WolfyUtilities, APIs and Utilities for Minecraft Spigot plugins
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.wolfyscript.utilities.common.gui;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
+import com.wolfyscript.utilities.NamespacedKey;
+import com.wolfyscript.utilities.common.WolfyUtils;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.Consumer;
+
+public abstract class ClusterCommonImpl<D extends Data> implements Cluster<D> {
+
+    private final WolfyUtils wolfyUtils;
+    private final Cluster<D> parent;
+    private final ComponentState<D>[] states;
+    private final StateSelector<D> stateSelector;
+    private final String id;
+    private final MenuComponent<D> entry;
+    private final Class<D> dataType;
+    private final BiMap<String, ? extends MenuComponent<D>> children;
+
+    protected ClusterCommonImpl(String id, Class<D> dataType, WolfyUtils wolfyUtils, Cluster<D> parent, StateSelector<D> stateSelector, ComponentState<D>[] states, BiMap<String, ? extends MenuComponent<D>> children, MenuComponent<D> entry) {
+        Preconditions.checkNotNull(id);
+        Preconditions.checkNotNull(stateSelector);
+        Preconditions.checkNotNull(dataType);
+        Preconditions.checkNotNull(wolfyUtils);
+        Preconditions.checkNotNull(entry, "Cluster must have an entry Component!");
+        Preconditions.checkArgument(states != null && states.length > 0, "ComponentStates cannot be null or empty!");
+        this.parent = parent;
+        this.dataType = dataType;
+        this.wolfyUtils = wolfyUtils;
+        this.id = id;
+        this.stateSelector = stateSelector;
+        this.states = states;
+        this.children = HashBiMap.create(children);
+        this.entry = entry;
+    }
+
+    protected ClusterCommonImpl(String id, Cluster<D> parent, StateSelector<D> stateSelector, ComponentState<D>[] states, BiMap<String, ? extends MenuComponent<D>> children, MenuComponent<D> entry) {
+        this(id, parent.dataType(), parent.getWolfyUtils(), parent, stateSelector, states, children, entry);
+    }
+
+    protected ClusterCommonImpl(String id, WolfyUtils wolfyUtils, Class<D> dataType, StateSelector<D> stateSelector, ComponentState<D>[] states, BiMap<String, ? extends MenuComponent<D>> children, MenuComponent<D> entry) {
+        this(id, dataType, wolfyUtils, null, stateSelector, states, children, entry);
+    }
+
+    @Override
+    public String getID() {
+        return id;
+    }
+
+    @Override
+    public WolfyUtils getWolfyUtils() {
+        return wolfyUtils;
+    }
+
+    @Override
+    public Set<? extends MenuComponent<D>> children() {
+        return children.values();
+    }
+
+    @Override
+    public Class<D> dataType() {
+        return dataType;
+    }
+
+    @Override
+    public Cluster<D> parent() {
+        return parent;
+    }
+
+    @Override
+    public void open(GuiViewManager<D> viewManager, UUID player) {
+        // Redirect and open the entry component
+        entry().open(viewManager, player);
+    }
+
+    @Override
+    public Optional<Component<D>> getChild(String id) {
+        return Optional.ofNullable(children.get(id));
+    }
+
+    @Override
+    public ComponentState<D> getState(GuiHolder<D> holder) {
+        return states[stateSelector.run(holder, holder.getHandler().getData(), this)];
+    }
+
+    @Override
+    public void init() {
+
+    }
+
+    @Override
+    public MenuComponent<D> entry() {
+        return entry;
+    }
+
+    public static abstract class Builder<D extends Data> implements ClusterComponentBuilder<D> {
+
+        private final String subID;
+        private String entryID;
+        private final WolfyUtils wolfyUtils;
+        private final Cluster<D> parent;
+        private final Class<D> dataType;
+        private final List<ComponentState.Builder<D, ComponentState<D>>> stateBuilders = new ArrayList<>();
+        private final ClusterChildComponentBuilder<D> childComponentBuilder;
+        private StateSelector<D> stateSelector;
+
+        protected Builder(String subID, Cluster<D> parent, ClusterChildComponentBuilder<D> childComponentBuilder) {
+            Preconditions.checkNotNull(subID);
+            this.wolfyUtils = parent.getWolfyUtils();
+            this.parent = parent;
+            this.dataType = parent.dataType();
+            this.subID = subID;
+            this.childComponentBuilder = childComponentBuilder;
+        }
+
+        @Override
+        public final ClusterComponentBuilder<D> stateSelector(StateSelector<D> stateSelector) {
+            this.stateSelector = stateSelector;
+            return this;
+        }
+
+        public final ClusterComponentBuilder<D> state(Consumer<ComponentState.Builder<D, ComponentState<D>>> stateBuilderConsumer) {
+            ComponentState.Builder<D, ComponentState<D>> stateBuilder = new ComponentStateDefault.Builder<>(subID);
+            stateBuilderConsumer.accept(stateBuilder);
+            stateBuilders.add(stateBuilder);
+            return this;
+        }
+
+        @Override
+        public ClusterComponentBuilder<D> children(Consumer<ClusterChildComponentBuilder<D>> childComponentBuilderConsumer) {
+            childComponentBuilderConsumer.accept(this.childComponentBuilder);
+            return this;
+        }
+
+        @Override
+        public ClusterComponentBuilder<D> entry(String subID) {
+            this.entryID = subID;
+            return this;
+        }
+
+        @Override
+        public final Cluster<D> create() {
+            BiMap<String, ? extends MenuComponent<D>> children = childComponentBuilder.create();
+            Preconditions.checkState(!children.isEmpty(), "Cannot create Cluster without child Components!");
+            // Either use explicitly specified entry, or implicitly select it.
+            MenuComponent<D> entry;
+            if (entryID != null) {
+                entry = children.get(entryID);
+                Preconditions.checkState(entry != null, "Cannot find entry Component! Please check the explicitly specified entry id!");
+            } else {
+                entry = children.values().stream().findFirst().orElseThrow();
+            }
+            return constructImplementation(subID, dataType, wolfyUtils, parent,
+                    stateSelector == null ? (holder, data, component) -> 0 : stateSelector,
+                    stateBuilders.stream().map(ComponentState.Builder::create).<ComponentState<D>>toArray(ComponentState[]::new),
+                    children,
+                    entry
+            );
+        }
+        
+        protected abstract Cluster<D> constructImplementation(String subID, Class<D> dataType, WolfyUtils wolfyUtils, Cluster<D> parent, StateSelector<D> stateSelector, ComponentState<D>[] states, BiMap<String, ? extends MenuComponent<D>> children, MenuComponent<D> entry);
+
+    }
+
+    public static abstract class ChildBuilder<D extends Data> implements ClusterChildComponentBuilder<D> {
+
+        private final Cluster<D> parent;
+        private final BiMap<String, MenuComponent<D>> children = HashBiMap.create();
+
+        protected ChildBuilder(Cluster<D> parent) {
+            this.parent = parent;
+        }
+
+        @Override
+        public <CT extends Component.Builder<D, ?, ?>> ClusterChildComponentBuilder<D> custom(String subID, NamespacedKey builderId, Class<CT> builderType, Consumer<CT> builderConsumer) {
+            // TODO
+            return this;
+        }
+
+        @Override
+        public ClusterChildComponentBuilder<D> window(String id, Consumer<WindowComponentBuilder<D>> windowComponentBuilderConsumer) {
+            var windowBuilder = constructWindowBuilderImpl(id, parent);
+            windowComponentBuilderConsumer.accept(windowBuilder);
+            var window = windowBuilder.create();
+            children.put(id, window);
+            return this;
+        }
+
+        @Override
+        public ClusterChildComponentBuilder<D> cluster(String id, Consumer<ClusterComponentBuilder<D>> clusterComponentBuilderConsumer) {
+            ClusterComponentBuilder<D> clusterBuilder = constructClusterBuilderImpl(id, parent);
+            clusterComponentBuilderConsumer.accept(clusterBuilder);
+            var cluster = clusterBuilder.create();
+            children.put(id, cluster);
+            return this;
+        }
+
+        @Override
+        public BiMap<String, ? extends MenuComponent<D>> create() {
+            return children;
+        }
+
+        protected abstract ClusterComponentBuilder<D> constructClusterBuilderImpl(String id, Cluster<D> parent);
+
+        protected abstract WindowComponentBuilder<D> constructWindowBuilderImpl(String id, Cluster<D> parent);
+    }
+}

--- a/src/main/java/com/wolfyscript/utilities/common/gui/ClusterComponentBuilder.java
+++ b/src/main/java/com/wolfyscript/utilities/common/gui/ClusterComponentBuilder.java
@@ -1,0 +1,25 @@
+/*
+ *       WolfyUtilities, APIs and Utilities for Minecraft Spigot plugins
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.wolfyscript.utilities.common.gui;
+
+public interface ClusterComponentBuilder<D extends Data> extends Component.Builder<D, Cluster<D>, ClusterChildComponentBuilder<D>> {
+
+    ClusterComponentBuilder<D> entry(String subID);
+
+}

--- a/src/main/java/com/wolfyscript/utilities/common/gui/Component.java
+++ b/src/main/java/com/wolfyscript/utilities/common/gui/Component.java
@@ -1,0 +1,190 @@
+/*
+ *       WolfyUtilities, APIs and Utilities for Minecraft Spigot plugins
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.wolfyscript.utilities.common.gui;
+
+import com.wolfyscript.utilities.common.WolfyUtils;
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Deque;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Consumer;
+
+public interface Component<D extends Data> {
+
+    /**
+     * Gets the unique id (in context of the parent) of this component.
+     *
+     * @return The id of this component.
+     */
+    String getID();
+
+    /**
+     * Gets the global WolfyUtils instance, this component belongs to.
+     *
+     * @return The WolfyUtils API instance.
+     */
+    WolfyUtils getWolfyUtils();
+
+    /**
+     * The children of this Component; or an empty Set if there are no children.
+     *
+     * @return The child Components of this Component.
+     */
+    Set<? extends Component<D>> children();
+
+    /**
+     * The parent of this Component, or null if it is a root Component.
+     *
+     * @return The parent; or null if root Component.
+     */
+    Component<D> parent();
+
+    /**
+     *
+     * @param path
+     * @return
+     */
+    default Optional<Component<D>> getChild(String... path) {
+        if (path == null || path.length == 0) return Optional.of(this);
+        return getChild(path[0]).flatMap(component -> component.getChild(Arrays.copyOfRange(path, 1, path.length)));
+    }
+
+    Optional<Component<D>> getChild(String id);
+
+    /**
+     * The state of this Component for the specified
+     * {@link GuiHolder <D>} (e.g. Data, Permission, etc.)
+     *
+     * @param holder The holder to select the state for.
+     * @return The selected state for the holder.
+     */
+    ComponentState<D> getState(GuiHolder<D> holder);
+
+    /**
+     * Called when the Component is initialised.
+     *
+     */
+    void init();
+
+    default Deque<Component<D>> getPathToRoot() {
+        if (parent() == null) return new ArrayDeque<>();
+        Deque<Component<D>> path = parent().getPathToRoot();
+        path.add(parent());
+        return path;
+    }
+
+    /**
+     * Called when an interaction occurs inside the Component.<br>
+     * This may be called if a child Component is interacted with, for example a Button will cause this interaction to<br>
+     * propagate from the root Cluster, down the Windows to the Button that caused the interaction to be called.<br>
+     * <br>
+     * For this behaviour any implementation must first call the parent interaction, before continuing.<br>
+     * Only if there is no parent available (root Component) it continues, going back to the interaction cause.<br>
+     *
+     * @param holder             The holder that caused the interaction.
+     * @param data               The data of the handler (for convenience)
+     * @param interactionDetails The details about the interaction.
+     * @return The interaction result.
+     */
+    default InteractionResult interact(GuiHolder<D> holder, D data, InteractionDetails<D> interactionDetails) {
+        if (parent() != null) {
+            InteractionResult result = parent().interact(holder, data, interactionDetails);
+            if (result.isCancelled()) return result;
+        }
+        return getState(holder).interactCallback().interact(holder, data, this, interactionDetails);
+    }
+
+    /**
+     * Called after the interaction was completed.<br>
+     *
+     * @param holder    The holder that caused the interaction.
+     * @param data      The data of the handler (for convenience)
+     * @param interactionDetails    The details about the interaction.
+     */
+    default void postInteract(GuiHolder<D> holder, D data, InteractionDetails<D> interactionDetails) {
+        if (parent() != null) parent().postInteract(holder, data, interactionDetails);
+        getState(holder).interactPostCallback().run(holder, data, this, interactionDetails);
+    }
+
+    default void preRender(GuiHolder<D> holder, D data) {
+        if (parent() != null) parent().preRender(holder, data);
+    }
+
+    /**
+     * Called whenever a Component is rendered.
+     *
+     * @param holder
+     * @param data
+     * @param context
+     */
+    default void render(GuiHolder<D> holder, D data, RenderContext<D> context) {
+        if (parent() != null) parent().render(holder, data, context);
+        getState(holder).renderCallback().render(holder, data, this, context);
+    }
+
+    /**
+     * Builder used to create Components.<br>
+     * A Builder should always be preferred over creating Components via constructor.
+     *
+     * @param <D>
+     * @param <C>
+     */
+    interface Builder<D extends Data, C extends Component<D>, CB extends ChildComponentBuilder<D>> {
+
+        /**
+         * Specifies the StateSelector to use to select the Components state based on
+         * current data and holder.
+         *
+         * @param stateSelector The state selector to use.
+         * @return This builder for chaining.
+         */
+        Builder<D, C, CB> stateSelector(StateSelector<D> stateSelector);
+
+        /**
+         * Specifies the state of the Component.<br>
+         * Depending on the owning Component this may set or add the state.<br>
+         * For example, some Components can have multiple states that are selected using the state selector specified using {@link #stateSelector(StateSelector)}.<br>
+         * In these cases the states are added in the order of invocations of this method.<br>
+         * <br>
+         * The consumer must not call {@link ComponentState.Builder#create()} as that is handled by the implementation of this builder!
+         *
+         * @param builderConsumer The consumer that provides an instance of a new {@link ComponentState.Builder}
+         * @return This builder for chaining.
+         */
+        Builder<D, C, CB> state(Consumer<ComponentState.Builder<D, ComponentState<D>>> builderConsumer);
+
+        /**
+         * The ChildComponentBuilder is used to create and register
+         * child Components for this Component.
+         *
+         * @return The ChildComponentBuilder of this Component.
+         */
+        Component.Builder<D, C, CB> children(Consumer<CB> childComponentBuilder);
+
+        /**
+         * Creates the Component this builder belongs to.
+         *
+         * @return The new instance of the Component.
+         */
+        C create();
+
+    }
+
+}

--- a/src/main/java/com/wolfyscript/utilities/common/gui/ComponentState.java
+++ b/src/main/java/com/wolfyscript/utilities/common/gui/ComponentState.java
@@ -1,0 +1,114 @@
+/*
+ *       WolfyUtilities, APIs and Utilities for Minecraft Spigot plugins
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.wolfyscript.utilities.common.gui;
+
+/**
+ * <p>
+ * The State represents a State of a Component, that handles the functionality of the Component.<br>
+ * It provides several runtime callbacks that are called whenever an interaction or render request occurs.
+ * </p>
+ * <p>
+ * For example inside Windows and Buttons these States are used to draw the proper icons and textures of the GUI and handle the interactions and data manipulation.
+ * <br>
+ * Buttons like ToggleButtons use two states, and can sync it to the provided data ({@link D}) using the {@link StateSelector}.
+ * </p>
+ * <p>
+ * The State of a Component is independent of its children and won't change if a children changes its state.<br>
+ * Instead, the state is selected based on the data of the {@link GuiViewManager<D>} each time an update occurs.
+ * </p>
+ *
+ * @param <D> The type of data.
+ */
+public interface ComponentState<D extends Data> {
+
+    /**
+     * The key of the state. This is mostly used for translations.<br>
+     * By default, it is the same as the owner Component.
+     * But it can be different or a sub key from the owner key.
+     *
+     * @return The key of the state.
+     */
+    String key();
+
+    /**
+     * Called whenever an interaction occurs.<br>
+     * This propagates from the root Component to the Component that caused the interaction.
+     *
+     * @return The interaction callback
+     */
+    InteractionCallback<D> interactCallback();
+
+    /**
+     * Called after each interaction.
+     * This propagates from the root Component to the Component that caused the interaction.
+     * This is called before the interaction of the child Component.
+     *
+     * @return The post interact callback
+     */
+    InteractionPostCallback<D> interactPostCallback();
+
+    /**
+     * Called before each render.
+     *
+     *
+     * @return
+     */
+    RenderPreCallback<D> renderPreCallback();
+
+    /**
+     * Called each time the Component or a child Component is rendered in the GUI.
+     *
+     *
+     * @return
+     */
+    RenderCallback<D> renderCallback();
+
+    interface Builder<D extends Data, S extends ComponentState<D>> {
+
+        /**
+         * Specifies the sub key of the state relative to the owner key or previously specified key or subKey, separated by a dot ('.').
+         * These keys are used as language keys to lookup translations in the lang files.
+         *
+         * @param subKey The sub key of this state.
+         * @return This Builder for chaining.
+         */
+        Builder<D, S> subKey(String subKey);
+
+        /**
+         * Specifies the key of the state.
+         * These keys are used as language keys to lookup translations in the lang files.
+         *
+         * @param key The key of this state.
+         * @return This Builder for chaining.
+         */
+        Builder<D, S> key(String key);
+
+        Builder<D, S> interact(InteractionCallback<D> interactionCallback);
+
+        Builder<D, S> interactPost(InteractionPostCallback<D> interactPostCallback);
+
+        Builder<D, S> renderPre(RenderPreCallback<D> renderPreCallback);
+
+        Builder<D, S> render(RenderCallback<D> renderCallback);
+
+        S create();
+
+    }
+
+}

--- a/src/main/java/com/wolfyscript/utilities/common/gui/ComponentStateDefault.java
+++ b/src/main/java/com/wolfyscript/utilities/common/gui/ComponentStateDefault.java
@@ -1,0 +1,124 @@
+/*
+ *       WolfyUtilities, APIs and Utilities for Minecraft Spigot plugins
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.wolfyscript.utilities.common.gui;
+
+import com.google.common.base.Preconditions;
+import java.util.Objects;
+
+public class ComponentStateDefault<D extends Data> implements ComponentState<D> {
+
+        private final String key;
+        private final InteractionCallback<D> interactionCallback;
+        private final InteractionPostCallback<D> interactPostCallback;
+        private final RenderPreCallback<D> renderPreCallback;
+        private final RenderCallback<D> renderCallback;
+
+        protected ComponentStateDefault(String key, InteractionCallback<D> interactionCallback, InteractionPostCallback<D> interactPostCallback, RenderPreCallback<D> renderPreCallback, RenderCallback<D> renderCallback) {
+            this.key = key;
+            this.interactionCallback = interactionCallback;
+            this.interactPostCallback = interactPostCallback;
+            this.renderPreCallback = renderPreCallback;
+            this.renderCallback = renderCallback;
+        }
+
+        @Override
+        public InteractionCallback<D> interactCallback() {
+            return interactionCallback;
+        }
+
+        @Override
+        public InteractionPostCallback<D> interactPostCallback() {
+            return interactPostCallback;
+        }
+
+        @Override
+        public RenderCallback<D> renderCallback() {
+            return renderCallback;
+        }
+
+        @Override
+        public RenderPreCallback<D> renderPreCallback() {
+            return renderPreCallback;
+        }
+
+        @Override
+        public String key() {
+            return key;
+        }
+
+        public static class Builder<D extends Data> implements ComponentState.Builder<D, ComponentState<D>> {
+
+            private String key;
+            private InteractionCallback<D> interactionCallback;
+            private InteractionPostCallback<D> interactPostCallback;
+            private RenderPreCallback<D> renderPreCallback;
+            private RenderCallback<D> renderCallback;
+
+            protected Builder(String ownerID) {
+                this.key = ownerID;
+            }
+
+            @Override
+            public Builder<D> subKey(String subKey) {
+                this.key += "." + subKey;
+                return this;
+            }
+
+            @Override
+            public Builder<D> key(String key) {
+                this.key = key;
+                return this;
+            }
+
+            @Override
+            public Builder<D> interact(InteractionCallback<D> interactionCallback) {
+                this.interactionCallback = interactionCallback;
+                return this;
+            }
+
+            @Override
+            public Builder<D> interactPost(InteractionPostCallback<D> interactPostCallback) {
+                this.interactPostCallback = interactPostCallback;
+                return this;
+            }
+
+            @Override
+            public Builder<D> renderPre(RenderPreCallback<D> renderPreCallback) {
+                this.renderPreCallback = renderPreCallback;
+                return null;
+            }
+
+            @Override
+            public Builder<D> render(RenderCallback<D> renderCallback) {
+                this.renderCallback = renderCallback;
+                return null;
+            }
+
+            @Override
+            public ComponentStateDefault<D> create() {
+                Preconditions.checkNotNull(renderCallback, "Cannot create Component without a RenderCallback!");
+                final var interactCallback = Objects.requireNonNullElseGet(this.interactionCallback, () -> (holder, data, component, details) -> InteractionResult.def());
+                final var interactPostCallback = Objects.requireNonNullElseGet(this.interactPostCallback, () -> (holder, data, component, details) -> {});
+                final var renderPreCallback = Objects.requireNonNullElseGet(this.renderPreCallback, () -> (holder, data, component, context) -> {});
+                final var renderCallback = Objects.requireNonNullElseGet(this.renderCallback, () -> (holder, data, component, context) -> {});
+
+                return new ComponentStateDefault<>(key, interactCallback, interactPostCallback, renderPreCallback, renderCallback);
+            }
+        }
+    }

--- a/src/main/java/com/wolfyscript/utilities/common/gui/Data.java
+++ b/src/main/java/com/wolfyscript/utilities/common/gui/Data.java
@@ -1,0 +1,24 @@
+/*
+ *       WolfyUtilities, APIs and Utilities for Minecraft Spigot plugins
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.wolfyscript.utilities.common.gui;
+
+/**
+ * Data object that can be extended to store custom data for GUI Views.<br>
+ */
+public abstract class Data { }

--- a/src/main/java/com/wolfyscript/utilities/common/gui/DragInteractionDetails.java
+++ b/src/main/java/com/wolfyscript/utilities/common/gui/DragInteractionDetails.java
@@ -2,7 +2,7 @@ package com.wolfyscript.utilities.common.gui;
 
 import java.util.Set;
 
-public interface GUIDragInteractionDetails extends GUIInteractionDetails {
+public interface DragInteractionDetails<D extends Data> extends InteractionDetails<D> {
 
     Set<Integer> getInventorySlots();
 

--- a/src/main/java/com/wolfyscript/utilities/common/gui/GUIInteractionDetails.java
+++ b/src/main/java/com/wolfyscript/utilities/common/gui/GUIInteractionDetails.java
@@ -1,9 +1,0 @@
-package com.wolfyscript.utilities.common.gui;
-
-public interface GUIInteractionDetails {
-
-    boolean isCancelled();
-
-    ButtonInteractionResult.ResultType getResultType();
-
-}

--- a/src/main/java/com/wolfyscript/utilities/common/gui/GuiAPIManager.java
+++ b/src/main/java/com/wolfyscript/utilities/common/gui/GuiAPIManager.java
@@ -1,0 +1,32 @@
+/*
+ *       WolfyUtilities, APIs and Utilities for Minecraft Spigot plugins
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.wolfyscript.utilities.common.gui;
+
+import java.util.UUID;
+import java.util.function.Consumer;
+
+public interface GuiAPIManager {
+
+    <D extends Data> void registerCluster(String id, Class<D> dataType, Consumer<ClusterComponentBuilder<D>> clusterBuilderConsumer);
+
+    <D extends Data> GuiViewManager<D> createView(String clusterId, Class<D> dataType, UUID... viewers);
+
+    <D extends Data> GuiViewManager<D> createViewAndOpen(String clusterID, Class<D> dataType, UUID... players);
+
+}

--- a/src/main/java/com/wolfyscript/utilities/common/gui/GuiAPIManager.java
+++ b/src/main/java/com/wolfyscript/utilities/common/gui/GuiAPIManager.java
@@ -18,15 +18,70 @@
 
 package com.wolfyscript.utilities.common.gui;
 
+import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Consumer;
 
+/**
+ * Handles the general GUI API and acts as an entry point to the whole creation of {@link Cluster}s and {@link GuiViewManager}s.<br>
+ * It stores all the registered {@link Cluster}s and allows to register new clusters via builders.<br>
+ * Additionally, it stores the {@link GuiViewManager}s that handle the views for players.
+ */
 public interface GuiAPIManager {
 
+    /**
+     * Registers a new cluster under the given id, using the specified custom {@link Data} type ({@link D}).<br>
+     * The builder consumer provides the newly constructed {@link ClusterComponentBuilder<D>}, which can then be used inside that consumer.<br>
+     * <b>It is not required to call the {@link ClusterComponentBuilder#create()} method, because that is done after the consumer function ends.</b>
+     *
+     * @param id The unique id of the cluster to register.
+     * @param dataType The type of the custom {@link Data} implementation.
+     * @param clusterBuilderConsumer The consumer that provides the new builder.
+     * @param <D> The type of the specified data implementation.
+     */
     <D extends Data> void registerCluster(String id, Class<D> dataType, Consumer<ClusterComponentBuilder<D>> clusterBuilderConsumer);
 
+    /**
+     * Gets the registered cluster with the specified id.<br>
+     * If the cluster is available it checks if it matches the provided type.<br>
+     * When the type does not match an empty Optional is returned instead.
+     *
+     * @param id The id of the cluster.
+     * @param dataType The type of the cluster.
+     * @return The registered cluster only if the id and data type matches; otherwise empty Optional.
+     * @param <D> The type of the data implementation.
+     */
+    <D extends Data> Optional<Cluster<D>> getCluster(String id, Class<D> dataType);
+
+    /**
+     * Gets the registered cluster with the specified id.<br>
+     *
+     * @param id The id of the cluster.
+     * @return The registered cluster only if the id matches; otherwise empty Optional.
+     */
+    Optional<Cluster<?>> getCluster(String id);
+
+    /**
+     * Creates a new view for the specified viewers, with the specified cluster as its root.<br>
+     * This gets the registered cluster using {@link #getCluster(String, Class)}.
+     *
+     * @param clusterId The id of the root cluster.
+     * @param dataType The type of the cluster data implementation.
+     * @param viewers The viewers of this view.
+     * @return The newly created view.
+     * @param <D> The type of the data implementation.
+     */
     <D extends Data> GuiViewManager<D> createView(String clusterId, Class<D> dataType, UUID... viewers);
 
-    <D extends Data> GuiViewManager<D> createViewAndOpen(String clusterID, Class<D> dataType, UUID... players);
+    /**
+     * Same as {@link #createView(String, Class, UUID...)} and opens the entry menu right after the creation of the view.
+     *
+     * @param clusterID The id of the root cluster.
+     * @param dataType The type of the cluster data implementation.
+     * @param viewers The viewers of this view.
+     * @return The newly created view.
+     * @param <D> The type of the data implementation.
+     */
+    <D extends Data> GuiViewManager<D> createViewAndOpen(String clusterID, Class<D> dataType, UUID... viewers);
 
 }

--- a/src/main/java/com/wolfyscript/utilities/common/gui/GuiAPIManagerCommonImpl.java
+++ b/src/main/java/com/wolfyscript/utilities/common/gui/GuiAPIManagerCommonImpl.java
@@ -1,0 +1,51 @@
+/*
+ *       WolfyUtilities, APIs and Utilities for Minecraft Spigot plugins
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.wolfyscript.utilities.common.gui;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
+import com.wolfyscript.utilities.common.WolfyUtils;
+import java.util.UUID;
+import java.util.function.Consumer;
+
+public abstract class GuiAPIManagerCommonImpl implements GuiAPIManager {
+
+    protected final WolfyUtils wolfyUtils;
+    private final BiMap<String, Cluster<?>> clustersMap = HashBiMap.create();
+
+    public GuiAPIManagerCommonImpl(WolfyUtils wolfyUtils) {
+        this.wolfyUtils = wolfyUtils;
+    }
+
+    public abstract <D extends Data> void registerCluster(String id, Class<D> dataType, Consumer<ClusterComponentBuilder<D>> clusterBuilderConsumer);
+
+    protected <D extends Data> void registerCluster(Cluster<D> cluster) {
+        Preconditions.checkArgument(!clustersMap.containsKey(cluster.getID()), "A cluster with the id '" + cluster.getID() + "' is already registered!");
+        clustersMap.put(cluster.getID(), cluster);
+    }
+
+    public <D extends Data> GuiViewManager<D> createViewAndOpen(String clusterID, Class<D> dataType, UUID... players) {
+        GuiViewManager<D> handler = createView(clusterID, dataType, players);
+        handler.openNew();
+        return handler;
+    }
+
+
+}

--- a/src/main/java/com/wolfyscript/utilities/common/gui/GuiAPIManagerCommonImpl.java
+++ b/src/main/java/com/wolfyscript/utilities/common/gui/GuiAPIManagerCommonImpl.java
@@ -22,6 +22,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
 import com.wolfyscript.utilities.common.WolfyUtils;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Consumer;
 
@@ -47,5 +48,18 @@ public abstract class GuiAPIManagerCommonImpl implements GuiAPIManager {
         return handler;
     }
 
+    @Override
+    @SuppressWarnings("unchecked")
+    public <D extends Data> Optional<Cluster<D>> getCluster(String id, Class<D> dataType) {
+        Cluster<?> cluster = clustersMap.get(id);
+        if (cluster != null && cluster.dataType().equals(dataType)) {
+            return Optional.of((Cluster<D>) cluster); // We checked the data type, so we can cast it.
+        }
+        return Optional.empty();
+    }
 
+    @Override
+    public Optional<Cluster<?>> getCluster(String id) {
+        return Optional.of(clustersMap.get(id));
+    }
 }

--- a/src/main/java/com/wolfyscript/utilities/common/gui/GuiHolder.java
+++ b/src/main/java/com/wolfyscript/utilities/common/gui/GuiHolder.java
@@ -1,0 +1,27 @@
+/*
+ *       WolfyUtilities, APIs and Utilities for Minecraft Spigot plugins
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.wolfyscript.utilities.common.gui;
+
+public interface GuiHolder<D extends Data> {
+
+    GuiViewManager<D> getHandler();
+
+    Window<D> getCurrentWindow();
+
+}

--- a/src/main/java/com/wolfyscript/utilities/common/gui/GuiHolder.java
+++ b/src/main/java/com/wolfyscript/utilities/common/gui/GuiHolder.java
@@ -20,7 +20,7 @@ package com.wolfyscript.utilities.common.gui;
 
 public interface GuiHolder<D extends Data> {
 
-    GuiViewManager<D> getHandler();
+    GuiViewManager<D> getViewManager();
 
     Window<D> getCurrentWindow();
 

--- a/src/main/java/com/wolfyscript/utilities/common/gui/GuiHolderCommonImpl.java
+++ b/src/main/java/com/wolfyscript/utilities/common/gui/GuiHolderCommonImpl.java
@@ -1,0 +1,40 @@
+/*
+ *       WolfyUtilities, APIs and Utilities for Minecraft Spigot plugins
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.wolfyscript.utilities.common.gui;
+
+public abstract class GuiHolderCommonImpl<D extends Data> implements GuiHolder<D> {
+
+    protected final Window<D> currentWindow;
+    protected final GuiViewManager<D> viewManager;
+
+    public GuiHolderCommonImpl(Window<D> currentWindow, GuiViewManager<D> viewManager) {
+        this.currentWindow = currentWindow;
+        this.viewManager = viewManager;
+    }
+
+    @Override
+    public Window<D> getCurrentWindow() {
+        return currentWindow;
+    }
+
+    @Override
+    public GuiViewManager<D> getViewManager() {
+        return viewManager;
+    }
+}

--- a/src/main/java/com/wolfyscript/utilities/common/gui/GuiViewManager.java
+++ b/src/main/java/com/wolfyscript/utilities/common/gui/GuiViewManager.java
@@ -1,0 +1,44 @@
+/*
+ *       WolfyUtilities, APIs and Utilities for Minecraft Spigot plugins
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.wolfyscript.utilities.common.gui;
+
+import com.wolfyscript.utilities.common.WolfyUtils;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+public interface GuiViewManager<D extends Data> {
+
+    void openNew(String... path);
+
+    void openNew();
+
+    void openPrevious();
+
+    D getData();
+
+    Cluster<D> getRoot();
+
+    Optional<MenuComponent<D>> getCurrentMenu();
+
+    Set<UUID> getViewers();
+
+    WolfyUtils getWolfyUtils();
+
+}

--- a/src/main/java/com/wolfyscript/utilities/common/gui/GuiViewManager.java
+++ b/src/main/java/com/wolfyscript/utilities/common/gui/GuiViewManager.java
@@ -22,23 +22,78 @@ import com.wolfyscript.utilities.common.WolfyUtils;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import org.jetbrains.annotations.NotNull;
 
+/**
+ * The GuiViewManager, as the name suggests, manages a view of the GUI for one or more players.<br>
+ * It contains the custom Data ({@link D}) object that stores all the required data of this view.<br>
+ *
+ * The view is immutable, so you need to create a new view each time you need to add a viewer or change the root.
+ *
+ * @param <D> The custom data object type.
+ */
 public interface GuiViewManager<D extends Data> {
 
+    /**
+     * Opens a new menu under the specific path.
+     * When the component at the specified path cannot be rendered (is not a window) it'll use the entry of that component.
+     *
+     * @param path The path to the menu to open.
+     */
     void openNew(String... path);
 
+    /**
+     * Opens the entry menu of this cluster.
+     */
     void openNew();
 
+    /**
+     * Opens the currently active menu without updating the history.
+     */
+    void open();
+
+    /**
+     * Goes back to the previously opened menu and opens it.
+     */
     void openPrevious();
 
+    /**
+     * Gets the data object of this view manager.
+     *
+     * @return The data of this view manager.
+     */
+    @NotNull
     D getData();
 
+    /**
+     * The root cluster of this view manager.
+     * This is used for methods like {@link #openNew()} to open the entry menu.
+     *
+     * @return The root cluster of this view manager.
+     */
     Cluster<D> getRoot();
 
+    /**
+     * Gets the currently active menu.
+     * This may be a {@link Window<D>}, {@link Cluster<D>}, or any other {@link MenuComponent<D>}.
+     *
+     * @return The currently active menu.
+     */
     Optional<MenuComponent<D>> getCurrentMenu();
 
+    /**
+     * Gets the viewers that are handled by this view manager.
+     * When using these UUIDS, make sure the associated player is actually online!
+     *
+     * @return A Set of the viewers, that are handled by this manager.
+     */
     Set<UUID> getViewers();
 
+    /**
+     * The API instance this manager belongs to.
+     *
+     * @return The API instance of this manager.
+     */
     WolfyUtils getWolfyUtils();
 
 }

--- a/src/main/java/com/wolfyscript/utilities/common/gui/GuiViewManagerCommonImpl.java
+++ b/src/main/java/com/wolfyscript/utilities/common/gui/GuiViewManagerCommonImpl.java
@@ -1,0 +1,100 @@
+/*
+ *       WolfyUtilities, APIs and Utilities for Minecraft Spigot plugins
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.wolfyscript.utilities.common.gui;
+
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.TypeLiteral;
+import com.wolfyscript.utilities.common.WolfyUtils;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+public abstract class GuiViewManagerCommonImpl<D extends Data> implements GuiViewManager<D> {
+
+    private final WolfyUtils wolfyUtils;
+    private final Cluster<D> root;
+    private final Deque<MenuComponent<D>> history;
+    private final Set<UUID> viewers;
+    private final D data;
+
+    protected GuiViewManagerCommonImpl(WolfyUtils wolfyUtils, Cluster<D> rootCluster, Set<UUID> viewers) {
+        this.wolfyUtils = wolfyUtils;
+        this.root = rootCluster;
+        this.history = new ArrayDeque<>();
+        this.viewers = viewers;
+        // Construct custom data instance
+        Injector injector = Guice.createInjector(binder -> {
+            binder.bind(WolfyUtils.class).toInstance(wolfyUtils);
+            binder.bind(Cluster.class).toInstance(root);
+            binder.bind(new TypeLiteral<GuiViewManager<D>>(){}).toInstance(this);
+            binder.bind(new TypeLiteral<Set<UUID>>(){}).toInstance(viewers);
+        });
+        data = injector.getInstance(rootCluster.dataType());
+    }
+
+    public D getData() {
+        return data;
+    }
+
+    @Override
+    public void openNew(String... path) {
+        root.getChild(path).ifPresent(component -> {
+            if (component instanceof MenuComponent<D> menu) {
+                for (UUID viewer : viewers) {
+                    menu.open(this, viewer);
+                }
+                history.push(menu); // push the new menu to the history
+            } else {
+                throw new IllegalArgumentException("Cannot open non-menu Component!");
+            }
+        });
+    }
+
+    @Override
+    public void openPrevious() {
+        history.poll(); // Remove active current menu
+        getCurrentMenu().ifPresent(previous -> {
+            // Do not add menu to history, as it is already available
+            viewers.forEach(uuid -> previous.open(this, uuid));
+        });
+    }
+
+    @Override
+    public Optional<MenuComponent<D>> getCurrentMenu() {
+        return Optional.ofNullable(history.peek());
+    }
+
+    @Override
+    public WolfyUtils getWolfyUtils() {
+        return wolfyUtils;
+    }
+
+    @Override
+    public Cluster<D> getRoot() {
+        return root;
+    }
+
+    @Override
+    public Set<UUID> getViewers() {
+        return Set.copyOf(viewers);
+    }
+}

--- a/src/main/java/com/wolfyscript/utilities/common/gui/GuiViewManagerCommonImpl.java
+++ b/src/main/java/com/wolfyscript/utilities/common/gui/GuiViewManagerCommonImpl.java
@@ -27,6 +27,7 @@ import java.util.Deque;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import org.jetbrains.annotations.NotNull;
 
 public abstract class GuiViewManagerCommonImpl<D extends Data> implements GuiViewManager<D> {
 
@@ -51,6 +52,7 @@ public abstract class GuiViewManagerCommonImpl<D extends Data> implements GuiVie
         data = injector.getInstance(rootCluster.dataType());
     }
 
+    @NotNull
     public D getData() {
         return data;
     }
@@ -67,6 +69,21 @@ public abstract class GuiViewManagerCommonImpl<D extends Data> implements GuiVie
                 throw new IllegalArgumentException("Cannot open non-menu Component!");
             }
         });
+    }
+
+    @Override
+    public void openNew() {
+        openNew(new String[0]);
+    }
+
+    @Override
+    public void open() {
+        if (history.isEmpty()) {
+            openNew();
+        } else {
+            MenuComponent<D> component = history.peek();
+            viewers.forEach(uuid -> component.open(this, uuid));
+        }
     }
 
     @Override

--- a/src/main/java/com/wolfyscript/utilities/common/gui/InteractionCallback.java
+++ b/src/main/java/com/wolfyscript/utilities/common/gui/InteractionCallback.java
@@ -1,0 +1,26 @@
+/*
+ *       WolfyUtilities, APIs and Utilities for Minecraft Spigot plugins
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.wolfyscript.utilities.common.gui;
+
+@FunctionalInterface
+public interface InteractionCallback<D extends Data> {
+
+    InteractionResult interact(GuiHolder<D> holder, D data, Component<D> component, InteractionDetails<D> details);
+
+}

--- a/src/main/java/com/wolfyscript/utilities/common/gui/InteractionDetails.java
+++ b/src/main/java/com/wolfyscript/utilities/common/gui/InteractionDetails.java
@@ -1,0 +1,10 @@
+package com.wolfyscript.utilities.common.gui;
+
+public interface InteractionDetails<D extends Data> {
+
+    boolean isCancelled();
+
+    InteractionResult.ResultType getResultType();
+
+
+}

--- a/src/main/java/com/wolfyscript/utilities/common/gui/InteractionPostCallback.java
+++ b/src/main/java/com/wolfyscript/utilities/common/gui/InteractionPostCallback.java
@@ -1,0 +1,25 @@
+/*
+ *       WolfyUtilities, APIs and Utilities for Minecraft Spigot plugins
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.wolfyscript.utilities.common.gui;
+
+@FunctionalInterface
+public interface InteractionPostCallback<D extends Data> {
+
+    void run(GuiHolder<D> holder, D data, Component<D> component, InteractionDetails<D> details);
+}

--- a/src/main/java/com/wolfyscript/utilities/common/gui/InteractionResult.java
+++ b/src/main/java/com/wolfyscript/utilities/common/gui/InteractionResult.java
@@ -1,14 +1,14 @@
 package com.wolfyscript.utilities.common.gui;
 
-public class ButtonInteractionResult {
+public class InteractionResult {
 
     private ResultType type;
 
-    ButtonInteractionResult() {
+    InteractionResult() {
         type = ResultType.DEFAULT;
     }
 
-    ButtonInteractionResult(ResultType type) {
+    InteractionResult(ResultType type) {
         this.type = type;
     }
 
@@ -28,18 +28,18 @@ public class ButtonInteractionResult {
         this.type = type;
     }
 
-    public static ButtonInteractionResult cancel(boolean cancelled) {
-        ButtonInteractionResult result = new ButtonInteractionResult();
+    public static InteractionResult cancel(boolean cancelled) {
+        InteractionResult result = new InteractionResult();
         result.setCancelled(cancelled);
         return result;
     }
 
-    public static ButtonInteractionResult def() {
-        return new ButtonInteractionResult();
+    public static InteractionResult def() {
+        return new InteractionResult();
     }
 
-    public static ButtonInteractionResult type(ResultType type) {
-        return new ButtonInteractionResult(type);
+    public static InteractionResult type(ResultType type) {
+        return new InteractionResult(type);
     }
 
     public enum ResultType {

--- a/src/main/java/com/wolfyscript/utilities/common/gui/MenuComponent.java
+++ b/src/main/java/com/wolfyscript/utilities/common/gui/MenuComponent.java
@@ -1,0 +1,29 @@
+/*
+ *       WolfyUtilities, APIs and Utilities for Minecraft Spigot plugins
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.wolfyscript.utilities.common.gui;
+
+import java.util.UUID;
+
+public interface MenuComponent<D extends Data> extends Component<D> {
+
+    @Override
+    MenuComponent<D> parent();
+
+    void open(GuiViewManager<D> guiHandler, UUID uuid);
+}

--- a/src/main/java/com/wolfyscript/utilities/common/gui/RenderCallback.java
+++ b/src/main/java/com/wolfyscript/utilities/common/gui/RenderCallback.java
@@ -1,0 +1,26 @@
+/*
+ *       WolfyUtilities, APIs and Utilities for Minecraft Spigot plugins
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.wolfyscript.utilities.common.gui;
+
+@FunctionalInterface
+public interface RenderCallback<D extends Data> {
+
+    void render(GuiHolder<D> holder, D data, Component<D> component, RenderContext<D> context);
+
+}

--- a/src/main/java/com/wolfyscript/utilities/common/gui/RenderContext.java
+++ b/src/main/java/com/wolfyscript/utilities/common/gui/RenderContext.java
@@ -1,0 +1,28 @@
+/*
+ *       WolfyUtilities, APIs and Utilities for Minecraft Spigot plugins
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.wolfyscript.utilities.common.gui;
+
+/**
+ * The data that contains all the information needed to render the Menu.
+ *
+ * @param <D>
+ */
+public interface RenderContext<D extends Data> {
+    //TODO
+}

--- a/src/main/java/com/wolfyscript/utilities/common/gui/RenderPreCallback.java
+++ b/src/main/java/com/wolfyscript/utilities/common/gui/RenderPreCallback.java
@@ -1,0 +1,26 @@
+/*
+ *       WolfyUtilities, APIs and Utilities for Minecraft Spigot plugins
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.wolfyscript.utilities.common.gui;
+
+@FunctionalInterface
+public interface RenderPreCallback<D extends Data> {
+
+    void run(GuiHolder<D> holder, D data, Component<D> component, RenderContext<D> context);
+
+}

--- a/src/main/java/com/wolfyscript/utilities/common/gui/SlotComponent.java
+++ b/src/main/java/com/wolfyscript/utilities/common/gui/SlotComponent.java
@@ -1,0 +1,34 @@
+/*
+ *       WolfyUtilities, APIs and Utilities for Minecraft Spigot plugins
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.wolfyscript.utilities.common.gui;
+
+import java.util.Set;
+
+public interface SlotComponent<D extends Data> extends Component<D> {
+
+    @Override
+    Set<? extends SlotComponent<D>> children();
+
+    int position();
+
+    int width();
+
+    int height();
+
+}

--- a/src/main/java/com/wolfyscript/utilities/common/gui/StateSelector.java
+++ b/src/main/java/com/wolfyscript/utilities/common/gui/StateSelector.java
@@ -1,0 +1,25 @@
+/*
+ *       WolfyUtilities, APIs and Utilities for Minecraft Spigot plugins
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.wolfyscript.utilities.common.gui;
+
+public interface StateSelector<D extends Data> {
+
+    int run(GuiHolder<D> holder, D data, Component<D> component);
+
+}

--- a/src/main/java/com/wolfyscript/utilities/common/gui/Window.java
+++ b/src/main/java/com/wolfyscript/utilities/common/gui/Window.java
@@ -1,0 +1,30 @@
+/*
+ *       WolfyUtilities, APIs and Utilities for Minecraft Spigot plugins
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.wolfyscript.utilities.common.gui;
+
+import java.util.Set;
+
+public interface Window<D extends Data> extends MenuComponent<D> {
+
+    @Override
+    MenuComponent<D> parent();
+
+    @Override
+    Set<? extends SlotComponent<D>> children();
+}

--- a/src/main/java/com/wolfyscript/utilities/common/gui/Window.java
+++ b/src/main/java/com/wolfyscript/utilities/common/gui/Window.java
@@ -18,7 +18,9 @@
 
 package com.wolfyscript.utilities.common.gui;
 
+import java.util.Optional;
 import java.util.Set;
+import net.kyori.adventure.text.Component;
 
 public interface Window<D extends Data> extends MenuComponent<D> {
 
@@ -27,4 +29,11 @@ public interface Window<D extends Data> extends MenuComponent<D> {
 
     @Override
     Set<? extends SlotComponent<D>> children();
+
+    Optional<WindowType> getType();
+
+    Optional<Integer> getSize();
+
+    Component createTitle(GuiHolder<D> holder);
+
 }

--- a/src/main/java/com/wolfyscript/utilities/common/gui/WindowChildComponentBuilder.java
+++ b/src/main/java/com/wolfyscript/utilities/common/gui/WindowChildComponentBuilder.java
@@ -1,0 +1,27 @@
+/*
+ *       WolfyUtilities, APIs and Utilities for Minecraft Spigot plugins
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.wolfyscript.utilities.common.gui;
+
+import com.google.common.collect.BiMap;
+
+public interface WindowChildComponentBuilder<D extends Data> extends ChildComponentBuilder<D> {
+
+    @Override
+    BiMap<String, ? extends SlotComponent<D>> create();
+}

--- a/src/main/java/com/wolfyscript/utilities/common/gui/WindowCommonImpl.java
+++ b/src/main/java/com/wolfyscript/utilities/common/gui/WindowCommonImpl.java
@@ -1,0 +1,165 @@
+/*
+ *       WolfyUtilities, APIs and Utilities for Minecraft Spigot plugins
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.wolfyscript.utilities.common.gui;
+
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
+import com.wolfyscript.utilities.NamespacedKey;
+import com.wolfyscript.utilities.common.WolfyUtils;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.Consumer;
+
+public abstract class WindowCommonImpl<D extends Data> implements Window<D> {
+
+    private final WolfyUtils wolfyUtils;
+    private final String id;
+    private final MenuComponent<D> parent;
+    private final ComponentState<D>[] states;
+    private final StateSelector<D> stateSelector;
+    private final BiMap<String, ? extends SlotComponent<D>> children;
+
+    protected WindowCommonImpl(String id, Cluster<D> parent, StateSelector<D> stateSelector, ComponentState<D>[] states, BiMap<String, ? extends SlotComponent<D>> children) {
+        this.id = id;
+        this.parent = parent;
+        this.wolfyUtils = parent.getWolfyUtils();
+        this.stateSelector = stateSelector;
+        this.states = states;
+        this.children = HashBiMap.create(children);
+    }
+
+    @Override
+    public WolfyUtils getWolfyUtils() {
+        return wolfyUtils;
+    }
+
+    @Override
+    public String getID() {
+        return id;
+    }
+
+    @Override
+    public Set<? extends SlotComponent<D>> children() {
+        return children.values();
+    }
+
+    @Override
+    public MenuComponent<D> parent() {
+        return parent;
+    }
+
+    @Override
+    public Optional<Component<D>> getChild(String id) {
+        return Optional.ofNullable(children.get(id));
+    }
+
+    @Override
+    public ComponentState<D> getState(GuiHolder<D> holder) {
+        return states[stateSelector.run(holder, holder.getHandler().getData(), this)];
+    }
+
+    public net.kyori.adventure.text.Component onUpdateTitle(GuiHolder<D> holder) {
+        return null;
+    }
+
+    @Override
+    public void init() {
+
+    }
+
+    @Override
+    public void open(GuiViewManager<D> handler, UUID player) {
+        // This is the final destination and can be opened
+        // Start rendering here
+
+
+    }
+
+    public static abstract class Builder<D extends Data> implements WindowComponentBuilder<D> {
+
+        protected final String subID;
+        protected final Cluster<D> parent;
+        protected StateSelector<D> stateSelector;
+        protected final List<ComponentState.Builder<D, ComponentState<D>>> stateBuilders = new ArrayList<>();
+        protected final WindowChildComponentBuilder<D> childComponentBuilder;
+
+        Builder(String subID, Cluster<D> parent) {
+            this.subID = subID;
+            this.parent = parent;
+            this.childComponentBuilder = new ChildBuilder<>(parent);
+        }
+
+        @Override
+        public Builder<D> stateSelector(StateSelector<D> stateSelector) {
+            this.stateSelector = stateSelector;
+            return this;
+        }
+
+        @Override
+        public Builder<D> state(Consumer<ComponentState.Builder<D, ComponentState<D>>> stateBuilderConsumer) {
+            ComponentState.Builder<D, ComponentState<D>> stateBuilder = new ComponentStateDefault.Builder<>(subID);
+            stateBuilderConsumer.accept(stateBuilder);
+            stateBuilders.add(stateBuilder);
+            return this;
+        }
+
+        @Override
+        public Builder<D> children(Consumer<WindowChildComponentBuilder<D>> childComponentBuilderConsumer) {
+            childComponentBuilderConsumer.accept(childComponentBuilder);
+            return this;
+        }
+
+        @Override
+        public Window<D> create() {
+            return constructImplementation(parent.getID() + "/" + subID,
+                    parent,
+                    stateSelector == null ? (holder, data, component) -> 0 : stateSelector,
+                    stateBuilders.stream().map(ComponentState.Builder::create).<ComponentState<D>>toArray(ComponentState[]::new),
+                    childComponentBuilder.create()
+            );
+        }
+
+        protected abstract Window<D> constructImplementation(String id, Cluster<D> cluster, StateSelector<D> stateSelector, ComponentState<D>[] states, BiMap<String, ? extends SlotComponent<D>> children);
+
+    }
+
+    static class ChildBuilder<D extends Data> implements WindowChildComponentBuilder<D> {
+
+        private final Cluster<D> parent;
+        private final BiMap<String, SlotComponent<D>> children = HashBiMap.create();
+
+        ChildBuilder(Cluster<D> parent) {
+            this.parent = parent;
+        }
+
+        @Override
+        public <CT extends Component.Builder<D, ?, ?>> WindowChildComponentBuilder<D> custom(String subID, NamespacedKey builderId, Class<CT> builderType, Consumer<CT> builderConsumer) {
+            // TODO
+            return this;
+        }
+
+        @Override
+        public BiMap<String, ? extends SlotComponent<D>> create() {
+            return children;
+        }
+    }
+}

--- a/src/main/java/com/wolfyscript/utilities/common/gui/WindowComponentBuilder.java
+++ b/src/main/java/com/wolfyscript/utilities/common/gui/WindowComponentBuilder.java
@@ -1,0 +1,23 @@
+/*
+ *       WolfyUtilities, APIs and Utilities for Minecraft Spigot plugins
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.wolfyscript.utilities.common.gui;
+
+public interface WindowComponentBuilder<D extends Data> extends Component.Builder<D, Window<D>, WindowChildComponentBuilder<D>> {
+
+}

--- a/src/main/java/com/wolfyscript/utilities/common/gui/WindowComponentBuilder.java
+++ b/src/main/java/com/wolfyscript/utilities/common/gui/WindowComponentBuilder.java
@@ -20,4 +20,8 @@ package com.wolfyscript.utilities.common.gui;
 
 public interface WindowComponentBuilder<D extends Data> extends Component.Builder<D, Window<D>, WindowChildComponentBuilder<D>> {
 
+    WindowComponentBuilder<D> size(int size);
+
+    WindowComponentBuilder<D> type(WindowType type);
+
 }

--- a/src/main/java/com/wolfyscript/utilities/common/gui/WindowType.java
+++ b/src/main/java/com/wolfyscript/utilities/common/gui/WindowType.java
@@ -1,0 +1,28 @@
+/*
+ *       WolfyUtilities, APIs and Utilities for Minecraft Spigot plugins
+ *                      Copyright (C) 2021  WolfyScript
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.wolfyscript.utilities.common.gui;
+
+public enum WindowType {
+
+    CUSTOM,
+    DISPENSER,
+    DROPPER,
+    HOPPER
+
+}


### PR DESCRIPTION
The current GUI API is only available on Spigot. 
There should be a cross-platform (Spigot, Sponge, Paper) API, which then would make it easier to create cross-platform inventory GUIs.
Plus, the current GUI is pretty much hardcoded and not customizable outside Java classes. 

### API:
* [ ] Basic interface structure
* [ ] Basic common Implementation

* [ ] Component Builders
  * [ ] **Allow for builder sharing across platforms.** 
      Create a builder with a common implementation, then access it on each platform to extend it. 

* [ ] Config
  * [ ] Dynamically create builders from config.
  * [ ] Extend builders with states and actions via code.
  * [ ] Register builders that are done

### Implementation
* [ ] Spigot/Paper
* [ ] Sponge 
